### PR TITLE
feat: export `hcl::parse`

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -39,6 +39,12 @@ impl Deserializer {
 
 /// Deserialize an instance of type `T` from a string of HCL text.
 ///
+/// If preserving HCL semantics is required consider using [`hcl::parse`][parse] to parse the
+/// input into a [`Body`][Body].
+///
+/// [parse]: ../fn.parse.html
+/// [Body]: ../struct.Body.html
+///
 /// ## Example
 ///
 /// ```
@@ -85,6 +91,12 @@ where
 
 /// Deserialize an instance of type `T` from an IO stream of HCL.
 ///
+/// If preserving HCL semantics is required consider using [`hcl::parse`][parse] to parse the
+/// input into a [`Body`][Body].
+///
+/// [parse]: ../fn.parse.html
+/// [Body]: ../struct.Body.html
+/////
 /// ## Example
 ///
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,12 @@ pub mod de;
 pub mod error;
 mod number;
 mod parser;
-mod structure;
+pub mod structure;
 pub mod value;
 
 pub use de::{from_reader, from_str};
 pub use error::{Error, Result};
 pub use number::Number;
+pub use parser::parse;
+pub use structure::{Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder, Structure};
 pub use value::{Map, Value};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,6 +14,42 @@ use std::str::FromStr;
 struct HclParser;
 
 /// Parses a HCL `Body` from a `&str`.
+///
+/// If deserialization into a different type is preferred consider using [`hcl::from_str`][from_str].
+///
+/// [from_str]: ./de/fn.from_str.html
+///
+/// ## Example
+///
+/// ```
+/// use hcl::{Attribute, Block, Body};
+/// # use std::error::Error;
+/// #
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// let input = r#"
+///     some_attr = "foo"
+///
+///     some_block "some_block_label" {
+///       attr = "value"
+///     }
+/// "#;
+///
+/// let expected = Body::builder()
+///     .add_attribute(("some_attr", "foo"))
+///     .add_block(
+///         Block::builder("some_block")
+///             .add_label("some_block_label")
+///             .add_attribute(("attr", "value"))
+///             .build()
+///     )
+///     .build();
+///
+/// let body = hcl::parse(input)?;
+///
+/// assert_eq!(body, expected);
+/// #   Ok(())
+/// # }
+/// ```
 pub fn parse(input: &str) -> Result<Body> {
     let pair = HclParser::parse(Rule::Hcl, input)?.next().unwrap();
 

--- a/src/structure/attribute.rs
+++ b/src/structure/attribute.rs
@@ -15,7 +15,9 @@ use std::iter;
 /// crate's [`Value`] type.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Attribute {
+    /// The HCL attribute's key.
     pub key: String,
+    /// The value of the HCL attribute.
     pub value: Value,
 }
 

--- a/src/structure/block.rs
+++ b/src/structure/block.rs
@@ -15,8 +15,11 @@ use crate::Value;
 /// ```
 #[derive(Debug, PartialEq, Clone)]
 pub struct Block {
+    /// The block identifier.
     pub identifier: String,
+    /// Zero or more block labels.
     pub labels: Vec<BlockLabel>,
+    /// Represents the `Block`'s body.
     pub body: Body,
 }
 
@@ -87,7 +90,9 @@ where
 /// ```
 #[derive(Debug, PartialEq, Clone)]
 pub enum BlockLabel {
+    /// A bare HCL block label.
     Identifier(String),
+    /// A quoted string literal.
     StringLit(String),
 }
 
@@ -129,10 +134,11 @@ where
     }
 }
 
-/// `BlockBuilder` builds a HCL [`Block`].
+/// `BlockBuilder` builds an HCL [`Block`].
 ///
-/// The builder allows build the `Block` by adding labels, attributes and other nested blocks via
-/// chained method calls. A call to [`.build()`](BlockBuilder::build) produces the final `Block`.
+/// The builder allows to build the `Block` by adding labels, attributes and other nested blocks
+/// via chained method calls. A call to [`.build()`](BlockBuilder::build) produces the final
+/// `Block`.
 #[derive(Debug)]
 pub struct BlockBuilder {
     identifier: String,

--- a/src/structure/body.rs
+++ b/src/structure/body.rs
@@ -49,6 +49,10 @@ impl IntoIterator for Body {
     }
 }
 
+/// `BodyBuilder` builds a HCL [`Body`].
+///
+/// The builder allows to build the `Body` by adding attributes and other nested blocks via chained
+/// method calls. A call to [`.build()`](BodyBuilder::build) produces the final `Body`.
 #[derive(Debug, Default)]
 pub struct BodyBuilder(Vec<Structure>);
 

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -1,12 +1,14 @@
 //! Types to represent HCL structures.
 
-mod attribute;
-mod block;
-mod body;
+pub mod attribute;
+pub mod block;
+pub mod body;
 
-pub use self::attribute::Attribute;
-pub use self::block::{Block, BlockBuilder, BlockLabel};
-pub use self::body::{Body, BodyBuilder};
+pub use self::{
+    attribute::Attribute,
+    block::{Block, BlockBuilder, BlockLabel},
+    body::{Body, BodyBuilder},
+};
 use crate::{Map, Value};
 
 /// Represents an HCL structure.


### PR DESCRIPTION
This allows to parse HCL into a `Body` structure which preserves
context.