### PR TITLE
fix(parsers): Fix heredoc handling to match HCL spec

### DIFF
--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -50,9 +50,9 @@ ObjectItemExpr  = _{ Expression ~ ("=" | ":") ~ Expression }
 
 // Heredoc
 Heredoc = ${
-    ("<<-" | "<<") ~ PUSH(Identifier) ~ WHITESPACE+ ~
-    Template ~ WHITESPACE+ ~
-    POP
+    ("<<-" | "<<") ~ PUSH(Identifier) ~ NEWLINE ~
+    Template ~ 
+    WHITESPACE+ ~ POP
 }
 
 // Templates
@@ -63,7 +63,7 @@ Heredoc = ${
 //
 // Template           =  { TemplateInterpolation | TemplateDirective | TemplateLiteral }
 Template              =  { TemplateLiteral }
-TemplateLiteral       = _{ (ANY~ !PEEK)* }
+TemplateLiteral       = _{ (!(NEWLINE ~ WHITESPACE* ~ PEEK) ~ ANY)* }
 TemplateDirective     = _{ TemplateIf | TemplateFor }
 TemplateInterpolation = !{ ("${" | "${~") ~ ("\"" | Expression) ~ ("}" | "~}") }
 


### PR DESCRIPTION
Heredocs are newline sensitive.  
```
heredocTemplate = (
    ("<<" | "<<-") Identifier Newline
    (content as defined in prose above)
    Identifier Newline
);
````
The `Identifier` to start the heredoc must be terminated immediately by a newline, no whitespace allowed.  To end the heredoc it must be preceded by a newline and optional whitespace.  

The current implementation fails on this valid HCL.
```
heredoc { 
  data = <<EOF
  // blah blah terminates at EOF
  do logic
  EOF
}
```
Yet accepts this invalid HCL
```
heredoc { 
  data = <<EOF This is not valid EOF 
}
```
The grammar has been updated to correct that behavior.    It is also necessary to trim with `<<-` but that can be addressed later bringing up another topic integration testing.  
 
I'd like to propose integration testing similar to HCL's own [specsuite](https://github.com/hashicorp/hcl/tree/main/specsuite) to further protect the grammar and identify cases where the grammar isn't conformant.  I haven't wrote anything yet, but am willing to do so.