### PR TITLE
fix: heredocs must be newline-terminated

### DIFF
--- a/specsuite/hcl/heredoc-double-EOF.hcl.json
+++ b/specsuite/hcl/heredoc-double-EOF.hcl.json
@@ -2,7 +2,7 @@
   "message": "Double EOF are valid, as long as only the final is preceded by a newline and whitespace.",
   "body": {
     "heredoc": {
-      "data": "data = <<EOF # This is actually valid"
+      "data": "data = <<EOF # This is actually valid\n"
     }
   }
 }

--- a/specsuite/hcl/heredoc-indent.hcl.json
+++ b/specsuite/hcl/heredoc-indent.hcl.json
@@ -2,7 +2,7 @@
   "message": "Heredocs with <<- must strip whitespace, but only what is present before EOF",
   "body": {
     "heredoc": {
-      "data": "Indent was stripped.\n  And it was the correct amount."
+      "data": "Indent was stripped.\n  And it was the correct amount.\n"
     }
   }
 }

--- a/specsuite/hcl/heredoc.hcl
+++ b/specsuite/hcl/heredoc.hcl
@@ -25,13 +25,17 @@ EOT
 
   newlines_between = <<EOT
 Foo
+
 Bar
+
 Baz
 EOT
 
   indented_newlines_between = <<EOT
     Foo
+
     Bar
+
     Baz
   EOT
 
@@ -83,27 +87,19 @@ EOT
     Baz
   EOT
 
-  tabs = <<-EOT
-	Foo
-  Bar
-  Baz
-  EOT
-
-  unicode_spaces = <<-EOT
-     Foo (there's two "em spaces" before Foo there)
-    Bar
-    Baz
-  EOT
-
   newlines_between = <<-EOT
 Foo
+
 Bar
+
 Baz
 EOT
 
   indented_newlines_between = <<-EOT
     Foo
+
     Bar
+
     Baz
   EOT
 }

--- a/specsuite/hcl/heredoc.hcl.json
+++ b/specsuite/hcl/heredoc.hcl.json
@@ -2,26 +2,24 @@
   "message": "Heredoc cases from the original specsuite at https://github.com/hashicorp/hcl/blob/65731f3310963019707cb1ee851b7c12779a4f62/specsuite/tests/expressions/heredoc.hcl",
   "body": {
     "normal": {
-      "basic": "Foo\nBar\nBaz",
-      "indented": "    Foo\n    Bar\n    Baz",
-      "indented_more": "    Foo\n      Bar\n    Baz",
-      "interp": "    Foo\n    ${bar}\n    Baz",
-      "newlines_between": "Foo\nBar\nBaz",
-      "indented_newlines_between": "    Foo\n    Bar\n    Baz",
-      "marker_at_suffix": "    NOT EOT"
+      "basic": "Foo\nBar\nBaz\n",
+      "indented": "    Foo\n    Bar\n    Baz\n",
+      "indented_more": "    Foo\n      Bar\n    Baz\n",
+      "interp": "    Foo\n    ${bar}\n    Baz\n",
+      "newlines_between": "Foo\n\nBar\n\nBaz\n",
+      "indented_newlines_between": "    Foo\n\n    Bar\n\n    Baz\n",
+      "marker_at_suffix": "    NOT EOT\n"
     },
     "indent": {
-      "basic": "Foo\nBar\nBaz",
-      "indented": "Foo\nBar\nBaz",
-      "indented_more": "Foo\n  Bar\nBaz",
-      "indented_less": "  Foo\nBar\n  Baz",
-      "interp": "Foo\n${bar}\nBaz",
-      "interp_indented_more": "Foo\n  ${bar}\nBaz",
-      "interp_indented_less": "  Foo\n${space_bar}\n  Baz",
-      "tabs": "\tFoo\n  Bar\n  Baz",
-      "unicode_spaces": "  Foo (there's two \"em spaces\" before Foo there)\n Bar\n Baz",
-      "newlines_between": "Foo\nBar\nBaz",
-      "indented_newlines_between": "Foo\nBar\nBaz"
+      "basic": "Foo\nBar\nBaz\n",
+      "indented": "Foo\nBar\nBaz\n",
+      "indented_more": "Foo\n  Bar\nBaz\n",
+      "indented_less": "  Foo\nBar\n  Baz\n",
+      "interp": "Foo\n${bar}\nBaz\n",
+      "interp_indented_more": "Foo\n  ${bar}\nBaz\n",
+      "interp_indented_less": "  Foo\n${space_bar}\n  Baz\n",
+      "newlines_between": "Foo\n\nBar\n\nBaz\n",
+      "indented_newlines_between": "Foo\n\nBar\n\nBaz\n"
     }
   }
 }

--- a/specsuite/hcl/known-issues/heredoc-nonspace-indent.hcl
+++ b/specsuite/hcl/known-issues/heredoc-nonspace-indent.hcl
@@ -1,0 +1,13 @@
+indent {
+  tabs = <<-EOT
+	Foo
+  Bar
+  Baz
+  EOT
+
+  unicode_spaces = <<-EOT
+     Foo (there's two "em spaces" before Foo there)
+    Bar
+    Baz
+  EOT
+}

--- a/specsuite/hcl/known-issues/heredoc-nonspace-indent.hcl.json
+++ b/specsuite/hcl/known-issues/heredoc-nonspace-indent.hcl.json
@@ -1,0 +1,10 @@
+{
+  "ignore": true,
+  "message": "Tab and unicode space handling does not work properly yet. Heredoc cases from the original specsuite at https://github.com/hashicorp/hcl/blob/65731f3310963019707cb1ee851b7c12779a4f62/specsuite/tests/expressions/heredoc.hcl.",
+  "body": {
+    "indent": {
+      "tabs": "Foo\n Bar\n Baz\n",
+      "unicode_spaces": " Foo (there's two \"em spaces\" before Foo there)\nBar\nBaz\n"
+    }
+  }
+}

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -51,12 +51,13 @@ ObjectItemExpr  = _{ Expression ~ ("=" | ":") ~ Expression }
 // Heredoc
 Heredoc = ${
     HeredocIntro ~ PUSH(Identifier) ~ NEWLINE ~
-    Template ~ 
-    WHITESPACE+ ~ POP
+    HeredocContent ~
+    SpaceOrTab* ~ POP
 }
 HeredocIntro       = _{ (HeredocIntroIndent | HeredocIntroNormal) }
 HeredocIntroIndent =  { "<<-" }
 HeredocIntroNormal =  { "<<" }
+HeredocContent     = @{ Template ~ NEWLINE }
 
 // Templates
 //
@@ -66,7 +67,7 @@ HeredocIntroNormal =  { "<<" }
 //
 // Template           =  { TemplateInterpolation | TemplateDirective | TemplateLiteral }
 Template              =  { TemplateLiteral }
-TemplateLiteral       = _{ (!(NEWLINE ~ WHITESPACE* ~ PEEK) ~ ANY)* }
+TemplateLiteral       = _{ (!(NEWLINE ~ SpaceOrTab* ~ PEEK) ~ ANY)* }
 TemplateDirective     = _{ TemplateIf | TemplateFor }
 TemplateInterpolation = !{ ("${" | "${~") ~ ("\"" | Expression) ~ ("}" | "~}") }
 
@@ -148,4 +149,5 @@ BlockComment    = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 EoInlineComment = _{ NEWLINE | EOI }
 
 // Whitespace
-WHITESPACE = _{ " " | "\t" | NEWLINE }
+WHITESPACE = _{ SpaceOrTab | NEWLINE }
+SpaceOrTab = _{ " " | "\t" }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -430,7 +430,7 @@ resource "aws_s3_bucket" "mybucket" {
                 Heredoc(0, 54, [
                     HeredocIntroNormal(0, 2),
                     Identifier(2, 9),
-                    Template(10, 46)
+                    HeredocContent(10, 47)
                 ])
             ]
         };


### PR DESCRIPTION
In #11 support for stripping indent from herdocs was added along with
some heredoc test cases from the original specsuite.

However there were some issues with it that just surfaced now:

- As per the spec, heredocs must include a trailing newline which was
  stripped until now. The parser was adjusted to preserve these by
  explicitly making them part of the heredoc content.
- Some newlines in test cases got lost when adding the heredoc test
  cases from the original specsuite.
- I messed up the expected test results. Now the expected output is
  exactly the same as in the spec. This uncovered two issues that need
  fixing: handling of leading unicode spaces and tabs.

Ignoring the failure for the tab and unicode cases for now.