### PR TITLE
test(specsuite): improve failure output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,9 @@ features = ["derive"]
 version = "1.0.130"
 
 [dev-dependencies]
+assert-json-diff = "2.0.1"
 pretty_assertions = "1.0.0"
+textwrap = "0.15.0"
 
 [dev-dependencies.serde_json]
 features = ["preserve_order"]

--- a/specsuite/main.rs
+++ b/specsuite/main.rs
@@ -1,3 +1,4 @@
+use assert_json_diff::{assert_json_matches_no_panic, CompareMode, Config};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::error::Error;
@@ -94,10 +95,13 @@ fn main() -> Result<(), Box<dyn Error>> {
                     }
                 } else {
                     let msg = format!(
-                        "Comment: {}\nFound:\n{}\nExpected:\n{}",
+                        "Comment: {}\n{}",
                         expected.message,
-                        serde_json::to_string_pretty(&result)?,
-                        serde_json::to_string_pretty(&expected.body)?
+                        assert_json_matches_no_panic(
+                            &expected.body,
+                            &result,
+                            Config::new(CompareMode::Strict)
+                        ).unwrap_err()
                     );
 
                     if expected.ignore {
@@ -124,11 +128,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
             Status::Failed => {
                 failures += 1;
-                println!("{}\n{}", status, msg);
+                println!("{}\n{}", status, textwrap::indent(&msg, "  "));
             }
             Status::Ignored => {
                 ignored += 1;
-                println!("{}\n{}", status, msg);
+                println!("{}\n{}", status, textwrap::indent(&msg, "  "));
             }
         }
     }

--- a/specsuite/main.rs
+++ b/specsuite/main.rs
@@ -101,7 +101,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                             &expected.body,
                             &result,
                             Config::new(CompareMode::Strict)
-                        ).unwrap_err()
+                        )
+                        .unwrap_err()
                     );
 
                     if expected.ignore {


### PR DESCRIPTION
When a file containing a large number of tests fails, it's impossible with the current output to easily determine what failed without copying the output to text files and running a manual diff.  

This cleans it up by indenting to better associate the message with the test, and then using a diff function to pinpoint failures.

Example of the new failure output
```
test specsuite/hcl/heredoc.hcl - specsuite/hcl/heredoc.hcl.json ... FAILED
  Comment: Heredoc cases from the original specsuite at https://github.com/hashicorp/hcl/blob/65731f3310963019707cb1ee851b7c12779a4f62/specsuite/tests/expressions/heredoc.hcl
  json atoms at path ".normal.basic" are not equal:
      lhs:
          "Foo\nBar\nBaz"
      rhs:
          "Foo\nBar\nBaz\n"
test specsuite/hcl/invalid-heredoc.hcl - specsuite/hcl/invalid-heredoc.hcl.json ... ok
```