### PR TITLE
feat(structure): add `Expression` type

### DIFF
--- a/specsuite/hcl/operators.hcl
+++ b/specsuite/hcl/operators.hcl
@@ -1,0 +1,74 @@
+equality "==" {
+  exactly = "a" == "a"
+  not     = "a" == "b"
+
+  type_mismatch_number = "1" == 1
+  type_mismatch_bool   = "true" == true
+}
+
+equality "!=" {
+  exactly = "a" != "a"
+  not     = "a" != "b"
+
+  type_mismatch_number = "1" != 1
+  type_mismatch_bool   = "true" != true
+}
+
+inequality "<" {
+  lt = 1 < 2
+  gt = 2 < 1
+  eq = 1 < 1
+}
+
+inequality "<=" {
+  lt = 1 <= 2
+  gt = 2 <= 1
+  eq = 1 <= 1
+}
+
+inequality ">" {
+  lt = 1 > 2
+  gt = 2 > 1
+  eq = 1 > 1
+}
+
+inequality ">=" {
+  lt = 1 >= 2
+  gt = 2 >= 1
+  eq = 1 >= 1
+}
+
+arithmetic {
+  add      = 2 + 3.5
+  add_big  = 3.14159265358979323846264338327950288419716939937510582097494459 + 1
+  sub      = 3.5 - 2
+  sub_neg  = 2 - 3.5
+  mul      = 2 * 4.5
+  div      = 1 / 10
+  mod      = 11 % 5
+  mod_frac = 11 % 5.1
+}
+
+logical_binary "&&" {
+  tt = true && true
+  ft = false && true
+  tf = true && false
+  ff = false && false
+}
+
+logical_binary "||" {
+  tt = true || true
+  ft = false || true
+  tf = true || false
+  ff = false || false
+}
+
+logical_unary "!" {
+  t = !true
+  f = !false
+}
+
+conditional {
+  t = true ? "a" : "b"
+  f = false ? "a" : "b"
+}

--- a/specsuite/hcl/operators.hcl.json
+++ b/specsuite/hcl/operators.hcl.json
@@ -1,0 +1,75 @@
+{
+  "message": "Operator cases from the original specsuite at https://github.com/hashicorp/hcl/blob/ee38c67330bd3d45c373e4cc0166f4855d158339/specsuite/tests/expressions/operators.hcl",
+  "body": {
+    "equality": {
+      "==": {
+        "exactly": "${\"a\" == \"a\"}",
+        "not": "${\"a\" == \"b\"}",
+        "type_mismatch_number": "${\"1\" == 1}",
+        "type_mismatch_bool": "${\"true\" == true}"
+      },
+      "!=": {
+        "exactly": "${\"a\" != \"a\"}",
+        "not": "${\"a\" != \"b\"}",
+        "type_mismatch_number": "${\"1\" != 1}",
+        "type_mismatch_bool": "${\"true\" != true}"
+      }
+    },
+    "inequality": {
+      "<": {
+        "lt": "${1 < 2}",
+        "gt": "${2 < 1}",
+        "eq": "${1 < 1}"
+      },
+      "<=": {
+        "lt": "${1 <= 2}",
+        "gt": "${2 <= 1}",
+        "eq": "${1 <= 1}"
+      },
+      ">": {
+        "lt": "${1 > 2}",
+        "gt": "${2 > 1}",
+        "eq": "${1 > 1}"
+      },
+      ">=": {
+        "lt": "${1 >= 2}",
+        "gt": "${2 >= 1}",
+        "eq": "${1 >= 1}"
+      }
+    },
+    "arithmetic": {
+      "add": "${2 + 3.5}",
+      "add_big": "${3.14159265358979323846264338327950288419716939937510582097494459 + 1}",
+      "sub": "${3.5 - 2}",
+      "sub_neg": "${2 - 3.5}",
+      "mul": "${2 * 4.5}",
+      "div": "${1 / 10}",
+      "mod": "${11 % 5}",
+      "mod_frac": "${11 % 5.1}"
+    },
+    "logical_binary": {
+      "&&": {
+        "tt": "${true && true}",
+        "ft": "${false && true}",
+        "tf": "${true && false}",
+        "ff": "${false && false}"
+      },
+      "||": {
+        "tt": "${true || true}",
+        "ft": "${false || true}",
+        "tf": "${true || false}",
+        "ff": "${false || false}"
+      }
+    },
+    "logical_unary": {
+      "!": {
+        "t": "${!true}",
+        "f": "${!false}"
+      }
+    },
+    "conditional": {
+      "t": "${true ? \"a\" : \"b\"}",
+      "f": "${false ? \"a\" : \"b\"}"
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,8 @@ pub use de::{from_reader, from_slice, from_str};
 pub use error::{Error, Result};
 pub use number::Number;
 pub use parser::parse;
-pub use structure::{Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder, Structure};
+pub use structure::{
+    Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder, Expression, Object, ObjectKey,
+    RawExpression, Structure,
+};
 pub use value::{Map, Value};

--- a/src/structure/attribute.rs
+++ b/src/structure/attribute.rs
@@ -1,9 +1,9 @@
 //! Types to represent and build HCL attributes.
 
-use crate::Value;
+use super::{Expression, Value};
 use std::iter;
 
-/// Represents an HCL attribute which consists of an attribute key and value.
+/// Represents an HCL attribute which consists of an attribute key and a value expression.
 ///
 /// In HCL syntax this is represented as:
 ///
@@ -12,26 +12,26 @@ use std::iter;
 /// ```
 ///
 /// Use [`Attribute::new`] to construct an [`Attribute`] from a value that is convertible to this
-/// crate's [`Value`] type.
+/// crate's [`Expression`] type.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Attribute {
     /// The HCL attribute's key.
     pub key: String,
-    /// The value of the HCL attribute.
-    pub value: Value,
+    /// The value expression of the HCL attribute.
+    pub expr: Expression,
 }
 
 impl Attribute {
     /// Creates a new `Attribute` from an attribute key that is convertible into a `String` and an
-    /// attribute value that is convertible into a `Value`.
-    pub fn new<K, V>(key: K, value: V) -> Attribute
+    /// attribute value that is convertible into an `Expression`.
+    pub fn new<K, V>(key: K, expr: V) -> Attribute
     where
         K: Into<String>,
-        V: Into<Value>,
+        V: Into<Expression>,
     {
         Attribute {
             key: key.into(),
-            value: value.into(),
+            expr: expr.into(),
         }
     }
 
@@ -40,22 +40,22 @@ impl Attribute {
         &self.key
     }
 
-    /// Returns a reference to the attribute value.
-    pub fn value(&self) -> &Value {
-        &self.value
+    /// Returns a reference to the attribute value expression.
+    pub fn expr(&self) -> &Expression {
+        &self.expr
     }
 }
 
 impl From<Attribute> for Value {
     fn from(attr: Attribute) -> Value {
-        Value::from_iter(iter::once((attr.key, attr.value)))
+        Value::from_iter(iter::once((attr.key, attr.expr)))
     }
 }
 
 impl<K, V> From<(K, V)> for Attribute
 where
     K: Into<String>,
-    V: Into<Value>,
+    V: Into<Expression>,
 {
     fn from(pair: (K, V)) -> Attribute {
         Attribute::new(pair.0.into(), pair.1.into())

--- a/src/structure/body.rs
+++ b/src/structure/body.rs
@@ -302,6 +302,7 @@ impl BodyBuilder {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::RawExpression;
     use pretty_assertions::assert_eq;
     use serde_json::json;
 
@@ -326,6 +327,7 @@ mod test {
                 Block::builder("bar")
                     .add_label("baz")
                     .add_attribute(("bar", "baz"))
+                    .add_attribute(("baz", RawExpression::new("var.foo")))
                     .build(),
             )
             .add_attribute(("foo", "baz"))
@@ -339,7 +341,8 @@ mod test {
                         "foo": "bar"
                     },
                     {
-                        "bar": "baz"
+                        "bar": "baz",
+                        "baz": "${var.foo}"
                     }
                 ],
                 "qux": {

--- a/src/structure/expression.rs
+++ b/src/structure/expression.rs
@@ -1,0 +1,256 @@
+//! Types to represent HCL attribute value expressions.
+
+use crate::{Number, Value};
+use std::borrow::Cow;
+use std::fmt::{self, Display, Write};
+
+/// The object type used in the expression sub-language.
+pub type Object<K, V> = indexmap::IndexMap<K, V>;
+
+/// A type representing the expression sub-language is used within attribute definitions to specify
+/// values.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum Expression {
+    /// Represents a null value.
+    Null,
+    /// Represents a boolean.
+    Bool(bool),
+    /// Represents a number, either integer or float.
+    Number(Number),
+    /// Represents a string.
+    String(String),
+    /// Represents a tuple (list/array).
+    Tuple(Vec<Expression>),
+    /// Represents an object.
+    Object(Object<ObjectKey, Expression>),
+    /// Represents a raw HCL expression. This includes any expression kind that does match any of
+    /// the enum variants above. See [`RawExpression`] for more details.
+    Raw(RawExpression),
+}
+
+impl From<Expression> for Value {
+    fn from(expr: Expression) -> Self {
+        match expr {
+            Expression::Null => Value::Null,
+            Expression::Bool(b) => Value::Bool(b),
+            Expression::Number(n) => Value::Number(n),
+            Expression::String(s) => Value::String(s),
+            Expression::Tuple(tuple) => tuple.into_iter().collect(),
+            Expression::Object(object) => object.into_iter().collect(),
+            Expression::Raw(raw) => Value::String(raw.into()),
+        }
+    }
+}
+
+impl From<Value> for Expression {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Null => Expression::Null,
+            Value::Bool(b) => Expression::Bool(b),
+            Value::Number(n) => Expression::Number(n),
+            Value::String(s) => Expression::String(s),
+            Value::Array(array) => array.into_iter().collect(),
+            Value::Object(object) => object.into_iter().collect(),
+        }
+    }
+}
+
+macro_rules! impl_from_integer {
+    ($($ty:ty),*) => {
+        $(
+            impl From<$ty> for Expression {
+                fn from(n: $ty) -> Self {
+                    Expression::Number(n.into())
+                }
+            }
+        )*
+    };
+}
+
+impl_from_integer!(i8, i16, i32, i64, isize);
+impl_from_integer!(u8, u16, u32, u64, usize);
+
+impl From<f32> for Expression {
+    fn from(f: f32) -> Self {
+        Expression::Number(f.into())
+    }
+}
+
+impl From<f64> for Expression {
+    fn from(f: f64) -> Self {
+        Expression::Number(f.into())
+    }
+}
+
+impl From<bool> for Expression {
+    fn from(b: bool) -> Self {
+        Expression::Bool(b)
+    }
+}
+
+impl From<String> for Expression {
+    fn from(s: String) -> Self {
+        Expression::String(s)
+    }
+}
+
+impl From<&str> for Expression {
+    fn from(s: &str) -> Self {
+        Expression::String(s.to_string())
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Expression {
+    fn from(s: Cow<'a, str>) -> Self {
+        Expression::String(s.into_owned())
+    }
+}
+
+impl From<Object<ObjectKey, Expression>> for Expression {
+    fn from(f: Object<ObjectKey, Expression>) -> Self {
+        Expression::Object(f)
+    }
+}
+
+impl<T: Into<Expression>> From<Vec<T>> for Expression {
+    fn from(f: Vec<T>) -> Self {
+        Expression::Tuple(f.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<'a, T: Clone + Into<Expression>> From<&'a [T]> for Expression {
+    fn from(f: &'a [T]) -> Self {
+        Expression::Tuple(f.iter().cloned().map(Into::into).collect())
+    }
+}
+
+impl<T: Into<Expression>> FromIterator<T> for Expression {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Expression::Tuple(iter.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<K: Into<ObjectKey>, V: Into<Expression>> FromIterator<(K, V)> for Expression {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Expression::Object(
+            iter.into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        )
+    }
+}
+
+impl From<()> for Expression {
+    fn from((): ()) -> Self {
+        Expression::Null
+    }
+}
+
+impl From<RawExpression> for Expression {
+    fn from(raw: RawExpression) -> Self {
+        Expression::Raw(raw)
+    }
+}
+
+/// Represents an object key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ObjectKey {
+    /// Represents a bare unquoted identifer used as object key.
+    Identifier(String),
+    /// Represents a quoted string used as object key.
+    String(String),
+    /// Represents a raw HCL expression. This includes any expression kind that does match any of
+    /// the enum variants above. See [`RawExpression`] for more details.
+    RawExpression(RawExpression),
+}
+
+impl From<&str> for ObjectKey {
+    fn from(key: &str) -> Self {
+        ObjectKey::String(key.into())
+    }
+}
+
+impl From<String> for ObjectKey {
+    fn from(key: String) -> Self {
+        ObjectKey::String(key)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for ObjectKey {
+    fn from(key: Cow<'a, str>) -> Self {
+        ObjectKey::String(key.into())
+    }
+}
+
+impl From<ObjectKey> for String {
+    fn from(key: ObjectKey) -> Self {
+        key.to_string()
+    }
+}
+
+impl Display for ObjectKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ObjectKey::Identifier(k) | ObjectKey::String(k) => Display::fmt(k, f),
+            ObjectKey::RawExpression(raw) => Display::fmt(raw, f),
+        }
+    }
+}
+
+/// A type that holds the value of a raw expression.
+///
+/// As of now, anthing that is not a null value, a boolean, number, string, tuple or object is
+/// treated as raw expression and is not further parsed. This includes conditionals, operations,
+/// function calls, for expressions and variable expressions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RawExpression(String);
+
+impl RawExpression {
+    /// Creates a new `RawExpression` from something that can be converted to a `String`.
+    pub fn new<E>(expr: E) -> RawExpression
+    where
+        E: Into<String>,
+    {
+        RawExpression(expr.into())
+    }
+
+    /// Consumes `self` and returns the `RawExpression` as a `String`. If you want to represent the
+    /// `RawExpression` as an interpolated string, use `.to_string()` instead.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl From<String> for RawExpression {
+    fn from(expr: String) -> Self {
+        RawExpression::new(expr)
+    }
+}
+
+impl From<&str> for RawExpression {
+    fn from(expr: &str) -> Self {
+        RawExpression::new(expr)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for RawExpression {
+    fn from(expr: Cow<'a, str>) -> Self {
+        RawExpression::new(expr)
+    }
+}
+
+impl From<RawExpression> for String {
+    fn from(expr: RawExpression) -> Self {
+        expr.to_string()
+    }
+}
+
+impl Display for RawExpression {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("${")?;
+        f.write_str(&self.0)?;
+        f.write_char('}')
+    }
+}

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -48,11 +48,13 @@
 pub mod attribute;
 pub mod block;
 pub mod body;
+pub mod expression;
 
 pub use self::{
     attribute::Attribute,
     block::{Block, BlockBuilder, BlockLabel},
     body::{Body, BodyBuilder},
+    expression::{Expression, Object, ObjectKey, RawExpression},
 };
 use crate::{Map, Value};
 
@@ -153,7 +155,7 @@ impl IntoNodeMap for Body {
         self.into_iter().fold(Map::new(), |mut map, structure| {
             match structure {
                 Structure::Attribute(attr) => {
-                    map.insert(attr.key, Node::Value(attr.value));
+                    map.insert(attr.key, Node::Value(attr.expr.into()));
                 }
                 Structure::Block(block) => {
                     block


### PR DESCRIPTION
Adds an `Expression` type to improve the representation of `Attribute`
value expressions.

This is similar to `Value` with the difference that it also allows to
represents expressions that are neither a primitive (e.g. bool) or a
collection (e.g. object) as a `RawExpression`. In the future the
`Expression` enum can be extended to also receive variants for other
expressions like `Conditional` or `FunctionCall`.

For `RawExpression` acts as a catchall variant for those. Its string
representation is an interpolated string (`"${expression}"`).

The `Expression` type will become useful when implementing an HCL
serializer as there is some context needed to serialize expressions
correctly.

This is a BREAKING CHANGE but will still only result in a minor version
bump since we're still pre-v1.