### PR TITLE
feat: specialize deserialization for `hcl::Body`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ This crate provides functionality to deserialize and manipulate HCL data.
 The main types are `Deserializer` for deserializing data and `Value` which can
 be used to deserialize arbitrary HCL data.
 
-**Note**: Serializing to HCL is not supported.
+**Note**: Serializing to HCL is not supported yet.
 
 ## Example
+
+Deserialize arbitrary HCL according to the [HCL JSON
+Specification](https://github.com/hashicorp/hcl/blob/main/json/spec.md):
 
 ```rust
 use serde_json::{json, Value};
@@ -42,6 +45,44 @@ let expected = json!({
 let value: Value = hcl::from_str(input).unwrap();
 
 assert_eq!(value, expected);
+```
+
+If you need to preserve context about the HCL structure, deserialize into
+`hcl::Body` instead:
+
+```rust
+use hcl::{Block, Body, Expression};
+
+let input = r#"
+    some_attr = {
+      "foo" = [1, 2]
+      "bar" = true
+    }
+
+    some_block "some_block_label" {
+      attr = "value"
+    }
+"#;
+
+let expected = Body::builder()
+    .add_attribute((
+        "some_attr",
+        Expression::from_iter([
+            ("foo", Expression::from(vec![1, 2])),
+            ("bar", Expression::Bool(true)),
+        ]),
+    ))
+    .add_block(
+        Block::builder("some_block")
+            .add_label("some_block_label")
+            .add_attribute(("attr", "value"))
+            .build(),
+    )
+    .build();
+
+let body: Body = hcl::from_str(input).unwrap();
+
+assert_eq!(body, expected);
 ```
 
 ## License

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,13 +42,6 @@ impl Error {
         }
     }
 
-    pub(crate) fn expected<T>(token: T) -> Error
-    where
-        T: Display,
-    {
-        Error::new(format!("expected `{}`", token))
-    }
-
     /// Returns the `Location` in the input where the error happened, if available.
     pub fn location(&self) -> Option<&Location> {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,17 @@ pub use structure::{
     RawExpression, Structure,
 };
 pub use value::{Map, Value};
+
+trait OptionExt<T> {
+    /// Takes the value out of an `Option` and leaves `None` in place. This is a shorthand for the
+    /// pattern `.take().unwrap()`.
+    ///
+    /// Panics if the `Option` is `None`.
+    fn consume(&mut self) -> T;
+}
+
+impl<T> OptionExt<T> for Option<T> {
+    fn consume(&mut self) -> T {
+        self.take().unwrap()
+    }
+}

--- a/src/structure/body.rs
+++ b/src/structure/body.rs
@@ -1,14 +1,14 @@
 //! Types to represent and build HCL body structures.
 
 use super::{Attribute, Block, IntoNodeMap, Structure};
-use crate::Value;
+use crate::{Map, Value};
 use std::vec::IntoIter;
 
 /// Represents an HCL config file body.
 ///
 /// A `Body` consists of zero or more [`Attribute`] and [`Block`] HCL structures.
 #[derive(Debug, PartialEq, Default, Clone)]
-pub struct Body(Vec<Structure>);
+pub struct Body(pub Vec<Structure>);
 
 impl Body {
     /// Consumes `self` and returns the wrapped `Vec<Structure>`.
@@ -178,7 +178,16 @@ impl<'a> Iterator for BlockIterMut<'a> {
 
 impl From<Body> for Value {
     fn from(body: Body) -> Value {
-        Value::from_iter(body.into_node_map())
+        Value::Object(body.into())
+    }
+}
+
+impl From<Body> for Map<String, Value> {
+    fn from(body: Body) -> Map<String, Value> {
+        body.into_node_map()
+            .into_iter()
+            .map(|(k, v)| (k, v.into()))
+            .collect()
     }
 }
 

--- a/src/structure/de.rs
+++ b/src/structure/de.rs
@@ -1,0 +1,1138 @@
+//! Deserialize impls for HCL structure types.
+
+use super::{
+    marker, Attribute, Block, BlockLabel, Body, Expression, Object, ObjectKey, RawExpression,
+    Structure,
+};
+use crate::{Error, Number, OptionExt, Result};
+use indexmap::{map, IndexMap};
+use serde::de::{self, IntoDeserializer};
+use serde::forward_to_deserialize_any;
+use std::fmt::{self, Display};
+use std::vec;
+
+struct Fields(&'static [&'static str]);
+
+impl Display for Fields {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.0.len() {
+            0 => unreachable!(),
+            1 => write!(f, "`{}`", self.0[0]),
+            2 => write!(f, "`{}` or `{}`", self.0[0], self.0[1]),
+            _ => {
+                for (i, alt) in self.0.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "`{}`", alt)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+fn expected_one_of<E>(fields: &'static [&'static str]) -> E
+where
+    E: de::Error,
+{
+    de::Error::custom(format_args!(
+        "missing fields, expected one of {}",
+        Fields(fields)
+    ))
+}
+
+fn next_field_value<'de, V, T>(visitor: &mut V, name: &'static str) -> Result<T, V::Error>
+where
+    V: de::MapAccess<'de>,
+    T: de::Deserialize<'de>,
+{
+    match visitor.next_key::<&str>()? {
+        Some(field) if name == field => visitor.next_value(),
+        _ => Err(de::Error::missing_field(name)),
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Body {
+    fn deserialize<D>(deserializer: D) -> Result<Body, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct BodyVisitor;
+
+        impl<'de> de::Visitor<'de> for BodyVisitor {
+            type Value = Body;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an HCL body")
+            }
+
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::SeqAccess<'de>,
+            {
+                let mut structures = Vec::with_capacity(visitor.size_hint().unwrap_or(0));
+
+                while let Some(elem) = visitor.next_element()? {
+                    structures.push(elem);
+                }
+
+                Ok(Body(structures))
+            }
+        }
+
+        deserializer.deserialize_newtype_struct(marker::BODY_NAME, BodyVisitor)
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Structure {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct StructureVisitor;
+
+        impl<'de> de::Visitor<'de> for StructureVisitor {
+            type Value = Structure;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an HCL structure")
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                match visitor.next_key()? {
+                    Some(marker::ATTRIBUTE_FIELD) => {
+                        Ok(Structure::Attribute(visitor.next_value()?))
+                    }
+                    Some(marker::BLOCK_FIELD) => Ok(Structure::Block(visitor.next_value()?)),
+                    _ => Err(expected_one_of(&[
+                        marker::ATTRIBUTE_FIELD,
+                        marker::BLOCK_FIELD,
+                    ])),
+                }
+            }
+        }
+
+        deserializer.deserialize_map(StructureVisitor)
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Attribute {
+    fn deserialize<D>(deserializer: D) -> Result<Attribute, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct AttributeVisitor;
+
+        impl<'de> de::Visitor<'de> for AttributeVisitor {
+            type Value = Attribute;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an HCL attribute")
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let key = next_field_value(&mut visitor, marker::IDENT_FIELD)?;
+                let expr = next_field_value(&mut visitor, marker::VALUE_FIELD)?;
+
+                Ok(Attribute { key, expr })
+            }
+        }
+
+        deserializer.deserialize_map(AttributeVisitor)
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Block {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct BlockVisitor;
+
+        impl<'de> de::Visitor<'de> for BlockVisitor {
+            type Value = Block;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an HCL block")
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let identifier = next_field_value(&mut visitor, marker::IDENT_FIELD)?;
+                let labels = next_field_value(&mut visitor, marker::LABELS_FIELD)?;
+                let body = next_field_value(&mut visitor, marker::BODY_FIELD)?;
+
+                Ok(Block {
+                    identifier,
+                    labels,
+                    body,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(BlockVisitor)
+    }
+}
+
+impl<'de> de::Deserialize<'de> for BlockLabel {
+    fn deserialize<D>(deserializer: D) -> Result<BlockLabel, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct BlockLabelVisitor;
+
+        impl<'de> de::Visitor<'de> for BlockLabelVisitor {
+            type Value = BlockLabel;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an HCL block label")
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                match visitor.next_key()? {
+                    Some(marker::IDENT_FIELD) => Ok(BlockLabel::Identifier(visitor.next_value()?)),
+                    Some(marker::STRING_FIELD) => Ok(BlockLabel::StringLit(visitor.next_value()?)),
+                    _ => Err(expected_one_of(&[
+                        marker::IDENT_FIELD,
+                        marker::STRING_FIELD,
+                    ])),
+                }
+            }
+        }
+
+        deserializer.deserialize_map(BlockLabelVisitor)
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Expression {
+    fn deserialize<D>(deserializer: D) -> Result<Expression, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct ExpressionVisitor;
+
+        impl<'de> de::Visitor<'de> for ExpressionVisitor {
+            type Value = Expression;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an HCL expression")
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                match visitor.next_key()? {
+                    Some(marker::VALUE_FIELD) => {
+                        let value: ValueExpression = visitor.next_value()?;
+                        Ok(value.expr)
+                    }
+                    Some(marker::RAW_FIELD) => Ok(Expression::Raw(visitor.next_value()?)),
+                    _ => Err(expected_one_of(&[marker::VALUE_FIELD, marker::RAW_FIELD])),
+                }
+            }
+        }
+
+        deserializer.deserialize_map(ExpressionVisitor)
+    }
+}
+
+struct ValueExpression {
+    expr: Expression,
+}
+
+impl<'de> de::Deserialize<'de> for ValueExpression {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct ExpressionVisitor;
+
+        impl<'de> de::Visitor<'de> for ExpressionVisitor {
+            type Value = Expression;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("an HCL value expression")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Expression, E> {
+                Ok(Expression::Bool(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Expression, E> {
+                Ok(Expression::Number(value.into()))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Expression, E> {
+                Ok(Expression::Number(value.into()))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Expression, E> {
+                Ok(Expression::Number(value.into()))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Expression, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_string(value.to_owned())
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Expression, E> {
+                Ok(Expression::String(value))
+            }
+
+            fn visit_none<E>(self) -> Result<Expression, E> {
+                Ok(Expression::Null)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Expression, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                de::Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_unit<E>(self) -> Result<Expression, E> {
+                Ok(Expression::Null)
+            }
+
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Expression, V::Error>
+            where
+                V: de::SeqAccess<'de>,
+            {
+                let mut vec = Vec::with_capacity(visitor.size_hint().unwrap_or(0));
+
+                while let Some(elem) = visitor.next_element()? {
+                    vec.push(elem);
+                }
+
+                Ok(Expression::Array(vec))
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Expression, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut object = Object::with_capacity(visitor.size_hint().unwrap_or(0));
+
+                while let Some((key, value)) = visitor.next_entry()? {
+                    object.insert(key, value);
+                }
+
+                Ok(Expression::Object(object))
+            }
+        }
+
+        let expr = deserializer.deserialize_any(ExpressionVisitor)?;
+        Ok(ValueExpression { expr })
+    }
+}
+
+impl<'de> de::Deserialize<'de> for ObjectKey {
+    fn deserialize<D>(deserializer: D) -> Result<ObjectKey, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct ObjectKeyVisitor;
+
+        impl<'de> de::Visitor<'de> for ObjectKeyVisitor {
+            type Value = ObjectKey;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an HCL object key")
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                match visitor.next_key()? {
+                    Some(marker::IDENT_FIELD) => Ok(ObjectKey::Identifier(visitor.next_value()?)),
+                    Some(marker::STRING_FIELD) => Ok(ObjectKey::String(visitor.next_value()?)),
+                    Some(marker::RAW_FIELD) => Ok(ObjectKey::RawExpression(visitor.next_value()?)),
+                    _ => Err(expected_one_of(&[
+                        marker::IDENT_FIELD,
+                        marker::STRING_FIELD,
+                        marker::RAW_FIELD,
+                    ])),
+                }
+            }
+        }
+
+        deserializer.deserialize_map(ObjectKeyVisitor)
+    }
+}
+
+impl<'de> de::Deserialize<'de> for RawExpression {
+    fn deserialize<D>(deserializer: D) -> Result<RawExpression, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct RawExpressionVisitor;
+
+        impl<'de> de::Visitor<'de> for RawExpressionVisitor {
+            type Value = RawExpression;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an HCL raw expression")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(s.into())
+            }
+        }
+
+        deserializer.deserialize_str(RawExpressionVisitor)
+    }
+}
+
+pub(crate) struct BodyDeserializer {
+    value: Option<Body>,
+}
+
+impl BodyDeserializer {
+    pub(crate) fn new(value: Body) -> BodyDeserializer {
+        BodyDeserializer { value: Some(value) }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut BodyDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_seq(StructureSeqAccess::new(self.value.consume().into_inner()))
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map struct option unit newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+impl<'de> de::MapAccess<'de> for BodyDeserializer {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        match self.value {
+            Some(_) => seed
+                .deserialize(FieldDeserializer(marker::VALUE_FIELD))
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(self)
+    }
+}
+
+struct ExpressionSeqAccess {
+    iter: vec::IntoIter<Expression>,
+}
+
+impl ExpressionSeqAccess {
+    fn new(vec: Vec<Expression>) -> Self {
+        ExpressionSeqAccess {
+            iter: vec.into_iter(),
+        }
+    }
+}
+
+impl<'de> de::SeqAccess<'de> for ExpressionSeqAccess {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(expr) => seed
+                .deserialize(&mut ExpressionDeserializer::new(expr))
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.iter.size_hint().1
+    }
+}
+
+struct ExpressionMapAccess {
+    iter: map::IntoIter<ObjectKey, Expression>,
+    value: Option<Expression>,
+}
+
+impl ExpressionMapAccess {
+    fn new(map: IndexMap<ObjectKey, Expression>) -> Self {
+        ExpressionMapAccess {
+            iter: map.into_iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for ExpressionMapAccess {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                seed.deserialize(&mut ObjectKeyDeserializer::new(key))
+                    .map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut ExpressionDeserializer::new(self.value.consume()))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.iter.size_hint().1
+    }
+}
+
+struct StructureSeqAccess {
+    iter: vec::IntoIter<Structure>,
+}
+
+impl StructureSeqAccess {
+    fn new(vec: Vec<Structure>) -> Self {
+        StructureSeqAccess {
+            iter: vec.into_iter(),
+        }
+    }
+}
+
+impl<'de> de::SeqAccess<'de> for StructureSeqAccess {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(structure) => seed
+                .deserialize(&mut StructureDeserializer::new(structure))
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.iter.size_hint().1
+    }
+}
+
+struct StructureDeserializer {
+    value: Option<Structure>,
+}
+
+impl StructureDeserializer {
+    fn new(value: Structure) -> StructureDeserializer {
+        StructureDeserializer { value: Some(value) }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut StructureDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        let (field, value) = match self.value.consume() {
+            Structure::Attribute(attribute) => {
+                (marker::ATTRIBUTE_FIELD, Structure::Attribute(attribute))
+            }
+            Structure::Block(block) => (marker::BLOCK_FIELD, Structure::Block(block)),
+        };
+
+        visitor.visit_map(StructureAccess::new(field, value))
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map option unit struct newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+struct AttributeDeserializer {
+    value: Option<Attribute>,
+}
+
+impl AttributeDeserializer {
+    fn new(value: Attribute) -> AttributeDeserializer {
+        AttributeDeserializer { value: Some(value) }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut AttributeDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_map(AttributeAccess::new(self.value.consume()))
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map option unit struct newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+struct BlockDeserializer {
+    value: Option<Block>,
+}
+
+impl BlockDeserializer {
+    fn new(value: Block) -> BlockDeserializer {
+        BlockDeserializer { value: Some(value) }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut BlockDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_map(BlockAccess::new(self.value.consume()))
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map option unit struct newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+struct BlockLabelSeqDeserializer {
+    value: Option<Vec<BlockLabel>>,
+}
+
+impl BlockLabelSeqDeserializer {
+    fn new(value: Vec<BlockLabel>) -> BlockLabelSeqDeserializer {
+        BlockLabelSeqDeserializer { value: Some(value) }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut BlockLabelSeqDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_seq(BlockLabelSeqAccess::new(self.value.consume()))
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map option unit struct newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+struct BlockLabelDeserializer {
+    value: Option<BlockLabel>,
+}
+
+impl BlockLabelDeserializer {
+    fn new(value: BlockLabel) -> BlockLabelDeserializer {
+        BlockLabelDeserializer { value: Some(value) }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut BlockLabelDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        let (field, value) = match self.value.consume() {
+            BlockLabel::Identifier(identifier) => (marker::IDENT_FIELD, identifier),
+            BlockLabel::StringLit(string) => (marker::STRING_FIELD, string),
+        };
+
+        visitor.visit_map(StringFieldAccess::new(field, value))
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map option unit struct newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+struct ObjectKeyDeserializer {
+    value: Option<ObjectKey>,
+}
+
+impl ObjectKeyDeserializer {
+    fn new(value: ObjectKey) -> ObjectKeyDeserializer {
+        ObjectKeyDeserializer { value: Some(value) }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut ObjectKeyDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        let (field, value) = match self.value.consume() {
+            ObjectKey::Identifier(identifier) => (marker::IDENT_FIELD, identifier),
+            ObjectKey::String(string) => (marker::STRING_FIELD, string),
+            ObjectKey::RawExpression(expr) => (marker::RAW_FIELD, expr.into_inner()),
+        };
+
+        visitor.visit_map(StringFieldAccess::new(field, value))
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map option unit struct newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+struct FieldDeserializer(&'static str);
+
+impl<'de> de::Deserializer<'de> for FieldDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.0)
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map struct option unit newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+struct StructureAccess {
+    field: &'static str,
+    value: Option<Structure>,
+}
+
+impl StructureAccess {
+    fn new(field: &'static str, value: Structure) -> Self {
+        StructureAccess {
+            field,
+            value: Some(value),
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for StructureAccess {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(FieldDeserializer(self.field)).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        match self.value.consume() {
+            Structure::Attribute(attribute) => {
+                seed.deserialize(&mut AttributeDeserializer::new(attribute))
+            }
+            Structure::Block(block) => seed.deserialize(&mut BlockDeserializer::new(block)),
+        }
+    }
+}
+
+struct AttributeAccess {
+    key: Option<String>,
+    expr: Option<Expression>,
+}
+
+impl AttributeAccess {
+    fn new(attr: Attribute) -> Self {
+        AttributeAccess {
+            key: Some(attr.key),
+            expr: Some(attr.expr),
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for AttributeAccess {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        if self.key.is_some() {
+            seed.deserialize(FieldDeserializer(marker::IDENT_FIELD))
+                .map(Some)
+        } else if self.expr.is_some() {
+            seed.deserialize(FieldDeserializer(marker::VALUE_FIELD))
+                .map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        if self.key.is_some() {
+            seed.deserialize(self.key.consume().into_deserializer())
+        } else if self.expr.is_some() {
+            seed.deserialize(&mut ExpressionDeserializer::new(self.expr.consume()))
+        } else {
+            Err(de::Error::custom("invalid HCL attribute"))
+        }
+    }
+}
+
+struct BlockAccess {
+    identifier: Option<String>,
+    labels: Option<Vec<BlockLabel>>,
+    body: Option<Body>,
+}
+
+impl BlockAccess {
+    fn new(block: Block) -> Self {
+        BlockAccess {
+            identifier: Some(block.identifier),
+            labels: Some(block.labels),
+            body: Some(block.body),
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for BlockAccess {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        if self.identifier.is_some() {
+            seed.deserialize(FieldDeserializer(marker::IDENT_FIELD))
+                .map(Some)
+        } else if self.labels.is_some() {
+            seed.deserialize(FieldDeserializer(marker::LABELS_FIELD))
+                .map(Some)
+        } else if self.body.is_some() {
+            seed.deserialize(FieldDeserializer(marker::BODY_FIELD))
+                .map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        if self.identifier.is_some() {
+            seed.deserialize(self.identifier.consume().into_deserializer())
+        } else if self.labels.is_some() {
+            seed.deserialize(&mut BlockLabelSeqDeserializer::new(self.labels.consume()))
+        } else if self.body.is_some() {
+            seed.deserialize(&mut BodyDeserializer::new(self.body.consume()))
+        } else {
+            Err(de::Error::custom("invalid HCL block"))
+        }
+    }
+}
+
+struct StringFieldAccess {
+    field: &'static str,
+    value: Option<String>,
+}
+
+impl StringFieldAccess {
+    fn new(field: &'static str, value: String) -> Self {
+        StringFieldAccess {
+            field,
+            value: Some(value),
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for StringFieldAccess {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(FieldDeserializer(self.field)).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.value.consume().into_deserializer())
+    }
+}
+
+struct BlockLabelSeqAccess {
+    iter: vec::IntoIter<BlockLabel>,
+}
+
+impl BlockLabelSeqAccess {
+    fn new(vec: Vec<BlockLabel>) -> Self {
+        Self {
+            iter: vec.into_iter(),
+        }
+    }
+}
+
+impl<'de> de::SeqAccess<'de> for BlockLabelSeqAccess {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed
+                .deserialize(&mut BlockLabelDeserializer::new(value))
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.iter.size_hint().1
+    }
+}
+
+struct ExpressionDeserializer {
+    value: Option<Expression>,
+}
+
+impl ExpressionDeserializer {
+    fn new(value: Expression) -> ExpressionDeserializer {
+        ExpressionDeserializer { value: Some(value) }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut ExpressionDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value.consume() {
+            Expression::Raw(expr) => {
+                visitor.visit_map(StringFieldAccess::new(marker::RAW_FIELD, expr.into_inner()))
+            }
+            value => visitor.visit_map(ExpressionValueAccess::new(value)),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map option unit struct newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+struct ExpressionValueAccess {
+    value: Option<Expression>,
+}
+
+impl ExpressionValueAccess {
+    fn new(value: Expression) -> Self {
+        ExpressionValueAccess { value: Some(value) }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for ExpressionValueAccess {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(FieldDeserializer(marker::VALUE_FIELD))
+            .map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut ExpressionValueDeserializer::new(self.value.consume()))
+    }
+}
+
+struct ExpressionValueDeserializer {
+    value: Option<Expression>,
+}
+
+impl ExpressionValueDeserializer {
+    fn new(value: Expression) -> ExpressionValueDeserializer {
+        ExpressionValueDeserializer { value: Some(value) }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for &'a mut ExpressionValueDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value.consume() {
+            Expression::Null => visitor.visit_unit(),
+            Expression::Bool(b) => visitor.visit_bool(b),
+            Expression::Number(n) => match n {
+                Number::PosInt(i) => visitor.visit_u64(i),
+                Number::NegInt(i) => visitor.visit_i64(i),
+                Number::Float(f) => visitor.visit_f64(f),
+            },
+            Expression::String(s) => visitor.visit_string(s),
+            Expression::Array(array) => visitor.visit_seq(ExpressionSeqAccess::new(array)),
+            Expression::Object(object) => visitor.visit_map(ExpressionMapAccess::new(object)),
+            Expression::Raw(_) => unreachable!(),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option enum unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct identifier ignored_any
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_terraform() {
+        let input = r#"
+            resource "aws_s3_bucket" "mybucket" {
+              bucket        = "mybucket"
+              force_destroy = true
+
+              server_side_encryption_configuration {
+                rule {
+                  apply_server_side_encryption_by_default {
+                    kms_master_key_id = aws_kms_key.mykey.arn
+                    sse_algorithm     = "aws:kms"
+                  }
+                }
+              }
+
+              tags = {
+                var.dynamic   = true
+                "application" = "myapp"
+                team          = "bar"
+              }
+            }"#;
+
+        let expected = Body::builder()
+            .add_block(
+                Block::builder("resource")
+                    .add_label("aws_s3_bucket")
+                    .add_label("mybucket")
+                    .add_attribute(("bucket", "mybucket"))
+                    .add_attribute(("force_destroy", true))
+                    .add_block(
+                        Block::builder("server_side_encryption_configuration")
+                            .add_block(
+                                Block::builder("rule")
+                                    .add_block(
+                                        Block::builder("apply_server_side_encryption_by_default")
+                                            .add_attribute((
+                                                "kms_master_key_id",
+                                                RawExpression::new("aws_kms_key.mykey.arn"),
+                                            ))
+                                            .add_attribute(("sse_algorithm", "aws:kms"))
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
+                            .build(),
+                    )
+                    .add_attribute((
+                        "tags",
+                        Expression::from_iter([
+                            (
+                                ObjectKey::RawExpression("var.dynamic".into()),
+                                Expression::Bool(true),
+                            ),
+                            (
+                                ObjectKey::String("application".into()),
+                                Expression::String("myapp".into()),
+                            ),
+                            (
+                                ObjectKey::Identifier("team".into()),
+                                Expression::String("bar".into()),
+                            ),
+                        ]),
+                    ))
+                    .build(),
+            )
+            .build();
+
+        let body: Body = crate::from_str(input).unwrap();
+
+        assert_eq!(expected, body);
+    }
+}

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -48,6 +48,7 @@
 pub mod attribute;
 pub mod block;
 pub mod body;
+pub(crate) mod de;
 pub mod expression;
 
 pub use self::{
@@ -246,4 +247,22 @@ impl Node {
             (lhs, rhs) => *lhs = rhs.take(),
         }
     }
+}
+
+/// Special marker strings used as field/struct names during deserialization of HCL structure
+/// types. They are an internal implementation detail should not be leaked outside of the
+/// deserializer.
+pub(crate) mod marker {
+    // Marker for the `Body` type.
+    pub const BODY_NAME: &str = "$hcl::Body";
+
+    // Markers for HCL structure fields.
+    pub const ATTRIBUTE_FIELD: &str = "$hcl::attribute";
+    pub const BLOCK_FIELD: &str = "$hcl::block";
+    pub const BODY_FIELD: &str = "$hcl::body";
+    pub const IDENT_FIELD: &str = "$hcl::ident";
+    pub const LABELS_FIELD: &str = "$hcl::labels";
+    pub const RAW_FIELD: &str = "$hcl::raw";
+    pub const STRING_FIELD: &str = "$hcl::string";
+    pub const VALUE_FIELD: &str = "$hcl::value";
 }


### PR DESCRIPTION
This PR adds specialization for the `hcl::Body` type to the `Deserializer`. With this, it's possible to deserialize into `hcl::Body` directly to preserve context about the HCL structure. See the added example.