### PR TITLE
fix(serializer): do not emit newline if block body is empty

### DIFF
--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -182,6 +182,15 @@ qux = {
 }
 
 #[test]
+fn serialize_empty_block() {
+    let body = Body::builder()
+        .add_block(Block::builder("empty").build())
+        .build();
+
+    assert_eq!(to_string(&body).unwrap(), "empty {}\n");
+}
+
+#[test]
 fn serialize_errors() {
     assert!(to_string(&true).is_err());
     assert!(to_string("foo").is_err());


### PR DESCRIPTION
Previously, empty blocks were rendered as:

    empty {
    }

With this change they are rendered as:

    empty {}