### PR TITLE
fix: unescape strings while parsing

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,14 @@ pub enum Error {
 
     /// Represents generic IO errors.
     Io(io::Error),
+
+    /// Represents errors due to invalid escape characters that may occur when unescaping
+    /// user-provided strings.
+    InvalidEscape(char),
+
+    /// Represents errors due to invalid unicode code points that may occur when unescaping
+    /// user-provided strings.
+    InvalidUnicodeCodePoint(String),
 }
 
 impl Error {
@@ -63,6 +71,10 @@ impl Display for Error {
                 }
                 None => write!(f, "{}", msg),
             },
+            Error::InvalidEscape(c) => write!(f, "invalid escape sequence '\\{}'", c),
+            Error::InvalidUnicodeCodePoint(u) => {
+                write!(f, "invalid unicode code point '\\u{}'", u)
+            }
         }
     }
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -413,3 +413,33 @@ fn parse_hcl() {
 
     assert_eq!(body, expected);
 }
+
+#[test]
+fn unescape_strings() {
+    let input = r#"
+        block "label\\with\\backslashes" {
+          string_attr = "I \u2665 unicode"
+
+          object_attr = {
+            "key\nwith\nnewlines" = true
+          }
+        }
+    "#;
+
+    let body = parse(input).unwrap();
+
+    let expected = Body::builder()
+        .add_block(
+            Block::builder("block")
+                .add_label("label\\with\\backslashes")
+                .add_attribute(("string_attr", "I \u{2665} unicode"))
+                .add_attribute((
+                    "object_attr",
+                    Expression::from_iter([("key\nwith\nnewlines", true)]),
+                ))
+                .build(),
+        )
+        .build();
+
+    assert_eq!(body, expected);
+}

--- a/src/parser/unescape.rs
+++ b/src/parser/unescape.rs
@@ -1,0 +1,53 @@
+use crate::{Error, Result};
+use std::str::Chars;
+
+/// Takes in a string with backslash escapes written out with literal backslash characters and
+/// converts it to a string with the proper escaped characters.
+///
+/// ## Errors
+///
+/// Returns an error if an invalid or incomplete escape sequence or unicode code point is
+/// encountered.
+pub fn unescape(s: &str) -> Result<String> {
+    let mut buf = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    let mut scratch = String::new();
+
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            buf.push(c);
+            continue;
+        }
+
+        let c = match chars.next() {
+            Some('b') => '\u{0008}',
+            Some('f') => '\u{000C}',
+            Some('n') => '\n',
+            Some('r') => '\r',
+            Some('t') => '\t',
+            Some('\'') => '\'',
+            Some('\"') => '\"',
+            Some('\\') => '\\',
+            Some('u') => match unescape_unicode(&mut chars, &mut scratch) {
+                Some(c) => c,
+                None => return Err(Error::InvalidUnicodeCodePoint(scratch)),
+            },
+            Some(c) => return Err(Error::InvalidEscape(c)),
+            None => return Err(Error::Eof),
+        };
+
+        buf.push(c);
+    }
+
+    Ok(buf)
+}
+
+fn unescape_unicode(chars: &mut Chars<'_>, scratch: &mut String) -> Option<char> {
+    scratch.clear();
+
+    for _ in 0..4 {
+        scratch.push(chars.next()?);
+    }
+
+    char::from_u32(u32::from_str_radix(scratch, 16).ok()?)
+}


### PR DESCRIPTION
This initial implementation is relatively naive but it should be good enough for the start.