### PR TITLE
feat: add `hcl::body!` macro and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The main types are `Deserializer` for deserializing data, `Serializer` for
 serialization. Furthermore the provided `Body` and `Value` types can be used to
 construct HCL data or as a deserialization target.
 
+Some supporting macros like `body!` to build HCL data structures are provided
+as well.
+
 ## Deserialization examples
 
 Deserialize arbitrary HCL according to the [HCL JSON
@@ -118,6 +121,13 @@ assert_eq!(serialized, expected);
 
 Also have a look at the other examples provided in the [documentation of the
 `ser` module](https://docs.rs/hcl-rs/latest/hcl/ser/index.html).
+
+## Macros
+
+This crate provides a couple of macros to ease building HCL data structures.
+Have a look at [their
+documentation](https://docs.rs/hcl-rs/latest/hcl/macro.body.html) for usage
+examples.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,14 @@
 
 pub mod de;
 pub mod error;
+#[macro_use]
 mod macros;
 mod number;
 mod parser;
 pub mod ser;
 pub mod structure;
+#[cfg(test)]
+mod tests;
 pub mod value;
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod de;
 pub mod error;
+mod macros;
 mod number;
 mod parser;
 pub mod ser;
@@ -20,8 +21,8 @@ pub use parser::parse;
 pub use ser::{to_string, to_vec, to_writer};
 #[doc(inline)]
 pub use structure::{
-    Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder, Expression, Object, ObjectKey,
-    RawExpression, Structure,
+    ser::to_expression, Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder, Expression,
+    Object, ObjectKey, RawExpression, Structure,
 };
 #[doc(inline)]
 pub use value::{Map, Value};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -429,7 +429,7 @@ macro_rules! expression_internal {
 
     // Unexpected token after most recent element.
     (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
-        $crate::expression_unexpected!($unexpected)
+        $crate::hcl_unexpected!($unexpected)
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -518,13 +518,13 @@ macro_rules! expression_internal {
     // Misplaced equals. Trigger a reasonable error message.
     (@object $object:ident () (= $($rest:tt)*) ($equals:tt $($copy:tt)*)) => {
         // Takes no arguments so "no rules expected the token `:`".
-        $crate::expression_unexpected!($equals);
+        $crate::hcl_unexpected!($equals);
     };
 
     // Found a comma inside a key. Trigger a reasonable error message.
     (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
         // Takes no arguments so "no rules expected the token `,`".
-        $crate::expression_unexpected!($comma);
+        $crate::hcl_unexpected!($comma);
     };
 
     // Key is fully parenthesized. This avoids clippy double_parens false
@@ -535,7 +535,7 @@ macro_rules! expression_internal {
 
     // Refuse to absorb equals token into key expression.
     (@object $object:ident ($($key:tt)*) (= $($unexpected:tt)+) $copy:tt) => {
-        $crate::expression_expect_expression_comma!($($unexpected)+);
+        $crate::hcl_expect_expr_comma!($($unexpected)+);
     };
 
     // Munch a token into the current key.
@@ -590,12 +590,12 @@ macro_rules! expression_internal {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! expression_unexpected {
+macro_rules! hcl_unexpected {
     () => {};
 }
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! expression_expect_expression_comma {
+macro_rules! hcl_expect_expr_comma {
     ($e:expr , $($tt:tt)*) => {};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -134,19 +134,28 @@ macro_rules! body_internal {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! structure {
+    // Hide distracting implementation details from the generated rustdoc.
+    ($($structure:tt)+) => {
+        $crate::structure_internal!($($structure)+)
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! structure_internal {
     // Structure in braces.
-    ({ $($rest:tt)+ }) => {
-        $crate::structure!($($rest)+)
+    ({ $($structure:tt)+ }) => {
+        $crate::structure!($($structure)+)
     };
 
     // An attribute structure.
-    ($key:tt = $($rest:tt)+) => {
-        $crate::Structure::Attribute($crate::attr!($key = $($rest)+))
+    ($key:tt = $($expr:tt)+) => {
+        $crate::Structure::Attribute($crate::attr!($key = $($expr)+))
     };
 
     // A block structure.
-    ($($rest:tt)+) => {
-        $crate::Structure::Block($crate::block!($($rest)+))
+    ($($block:tt)+) => {
+        $crate::Structure::Block($crate::block!($($block)+))
     };
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,492 @@
+/// Construct an `hcl::Body` from HCL blocks and attributes.
+///
+/// The macro supports a subset of the HCL syntax. If you need more flexibility, use the
+/// [`BlockBuilder`][BlockBuilder] instead.
+///
+/// Unsupported syntax:
+///
+/// - Raw HCL expressions in attribute values and object keys
+/// - A mix of identifier and string block labels
+///
+/// [BlockBuilder]: ./struct.BlockBuilder.html
+///
+/// ```
+/// let body = hcl::body!({
+///     resource "aws_sns_topic" "topic" {
+///         name = "my-topic"
+///     }
+/// });
+///
+/// let expected = hcl::Body::builder()
+///     .add_block(
+///         hcl::Block::builder("resource")
+///             .add_label("aws_sns_topic")
+///             .add_label("topic")
+///             .add_attribute(("name", "my-topic"))
+///             .build()
+///     )
+///     .build();
+///
+/// assert_eq!(body, expected);
+/// ```
+///
+/// Attribute keys and block identifiers can be expressions:
+///
+/// ```
+/// let block_identifier = "resource";
+/// let attribute_key = "name";
+///
+/// let body = hcl::body!({
+///     (block_identifier) "aws_sns_topic" "topic" {
+///         (attribute_key) = "my-topic"
+///     }
+/// });
+///
+/// let expected = hcl::Body::builder()
+///     .add_block(
+///         hcl::Block::builder(block_identifier)
+///             .add_label("aws_sns_topic")
+///             .add_label("topic")
+///             .add_attribute((attribute_key, "my-topic"))
+///             .build()
+///     )
+///     .build();
+///
+/// assert_eq!(body, expected);
+/// ```
+#[macro_export]
+macro_rules! body {
+    // Empty body.
+    () => {
+        $crate::Body::default()
+    };
+
+    // Body in braces.
+    ({$($rest:tt)*}) => {
+        $crate::body!($($rest)*)
+    };
+
+    // Consumes all tokens and adds matched attributes and blocks to the body builder.
+    ($($rest:tt)*) => {
+        {
+            let mut builder = $crate::Body::builder();
+            $crate::body_internal!(@any builder $($rest)*);
+            builder.build()
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! body_internal {
+    // Add attribute to the builder and consume remaining structures.
+    (@attr $builder:ident ($attr:expr) ($($rest:tt)*)) => {
+        $builder = $builder.add_attribute($attr);
+        $crate::body_internal!(@any $builder $($rest)*);
+    };
+
+    // Add block to the builder and consume remaining structures.
+    (@block $builder:ident ($block:expr) ($($rest:tt)*)) => {
+        $builder = $builder.add_block($block);
+        $crate::body_internal!(@any $builder $($rest)*);
+    };
+
+    // Consume attribute.
+    (@any $builder:ident $key:tt = $expr:tt $($rest:tt)*) => {
+        $crate::body_internal!(@attr $builder ($crate::attr!($key = $expr)) ($($rest)*))
+    };
+
+    // Consume block with with identifiers as labels.
+    (@any $builder:ident $ident:ident $($label:ident)* {$($body:tt)*} $($rest:tt)*) => {
+        $crate::body_internal!(@block $builder ($crate::block!($ident $($label)* {$($body)*})) ($($rest)*))
+    };
+
+    // Consume block with with literals as labels.
+    (@any $builder:ident $ident:ident $($label:literal)* {$($body:tt)*} $($rest:tt)*) => {
+        $crate::body_internal!(@block $builder ($crate::block!($ident $($label)* {$($body)*})) ($($rest)*))
+    };
+
+    // Consume block labels from expressions.
+    (@any $builder:ident $ident:ident $(($label:expr))* {$($body:tt)*} $($rest:tt)*) => {
+        $crate::body_internal!(@block $builder ($crate::block!($ident $(($label))* {$($body)*})) ($($rest)*))
+    };
+
+    // Consume block with identifier from expression and identifiers as labels.
+    (@any $builder:ident ($ident:expr) $($label:ident)* {$($body:tt)*} $($rest:tt)*) => {
+        $crate::body_internal!(@block $builder ($crate::block!(($ident) $($label)* {$($body)*})) ($($rest)*))
+    };
+
+    // Consume block with identifier from expression and literals as labels.
+    (@any $builder:ident ($ident:expr) $($label:literal)* {$($body:tt)*} $($rest:tt)*) => {
+        $crate::body_internal!(@block $builder ($crate::block!(($ident) $($label)* {$($body)*})) ($($rest)*))
+    };
+
+    // Consume block with identifier from expression and labels from expressions.
+    (@any $builder:ident ($ident:expr) $(($label:expr))* {$($body:tt)*} $($rest:tt)*) => {
+        $crate::body_internal!(@block $builder ($crate::block!(($ident) $(($label))* {$($body)*})) ($($rest)*))
+    };
+
+    // Done, no more tokens to consume.
+    (@any $builder:ident) => {};
+}
+
+/// Construct an `hcl::Structure` which may be either an HCL attribute or block.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! structure {
+    // Structure in braces.
+    ({ $($rest:tt)+ }) => {
+        $crate::structure!($($rest)+)
+    };
+
+    // An attribute structure.
+    ($key:tt = $($rest:tt)+) => {
+        $crate::Structure::Attribute($crate::attr!($key = $($rest)+))
+    };
+
+    // A block structure.
+    ($($rest:tt)+) => {
+        $crate::Structure::Block($crate::block!($($rest)+))
+    };
+}
+
+/// Construct an `hcl::Attribute` from a key and a value expression.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! attr {
+    // Attribute in braces.
+    ({ $($rest:tt)+ }) => {
+        $crate::attr!($($rest)+)
+    };
+
+    // Attribute with identifier as key.
+    ($key:ident = $($expr:tt)+) => {
+        $crate::Attribute {
+            key: std::stringify!($key).to_owned(),
+            expr: $crate::expr!($($expr)+),
+        }
+    };
+
+    // Attribute with expression as key.
+    (($key:expr) = $($expr:tt)+) => {
+        $crate::Attribute {
+            key: ($key).into(),
+            expr: $crate::expr!($($expr)+),
+        }
+    };
+}
+
+/// Construct an `hcl::Block` from a block identifier, optional block labels and a block body.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! block {
+    // Block in braces.
+    ({ $($rest:tt)+ }) => {
+        $crate::block_internal!($($rest)+)
+    };
+
+    ($($rest:tt)+) => {
+        $crate::block_internal!($($rest)+)
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! block_internal {
+    // Normal block identifier.
+    ($ident:ident $($rest:tt)+) => {
+        $crate::block_internal!([std::stringify!($ident)] [] [$($rest)+])
+    };
+
+    // Expression as block identifier.
+    (($ident:expr) $($rest:tt)+) => {
+        $crate::block_internal!([$ident] [] [$($rest)+])
+    };
+
+    // Munch an identifier label.
+    ([$ident:expr] [$(($labels:expr))*] [$label:ident $($rest:tt)+]) => {
+        $crate::block_internal!([$ident] [$(($labels))* ($crate::block_label!($label))] [$($rest)+])
+    };
+
+    // Munch a literal expression label.
+    ([$ident:expr] [$(($labels:expr))*] [$label:literal $($rest:tt)+]) => {
+        $crate::block_internal!([$ident] [$(($labels))* ($crate::block_label!($label))] [$($rest)+])
+    };
+
+    // Munch an expression label.
+    ([$ident:expr] [$(($labels:expr))*] [($label:expr) $($rest:tt)+]) => {
+        $crate::block_internal!([$ident] [$(($labels))* ($crate::block_label!(($label)))] [$($rest)+])
+    };
+
+    // Done, no block labels.
+    ([$ident:expr] [] [{$($body:tt)*}]) => {
+        $crate::Block {
+            identifier: ($ident).into(),
+            labels: std::vec![],
+            body: $crate::body!($($body)*),
+        }
+    };
+
+    // Done, with block labels.
+    ([$ident:expr] [$(($labels:expr))+] [{$($body:tt)*}]) => {
+        $crate::Block {
+            identifier: ($ident).into(),
+            labels: std::vec![$($labels),*],
+            body: $crate::body!($($body)*),
+        }
+    };
+}
+
+/// Construct an `hcl::BlockLabel`.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! block_label {
+    ($ident:ident) => {
+        $crate::BlockLabel::Identifier(std::stringify!($ident).into())
+    };
+
+    (($expr:expr)) => {
+        $crate::BlockLabel::String(($expr).into())
+    };
+
+    ($literal:literal) => {
+        $crate::BlockLabel::String($literal.into())
+    };
+}
+
+/// Construct an `hcl::Expression` from an HCL attribute value expression literal.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! expr {
+    // Hide distracting implementation details from the generated rustdoc.
+    ($($expr:tt)+) => {
+        $crate::expr_internal!($($expr)+)
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! expr_internal {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: expr_internal!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        std::vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        std::vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        $crate::expr_internal!(@array [$($elems,)* $crate::expr_internal!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        $crate::expr_internal!(@array [$($elems,)* $crate::expr_internal!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        $crate::expr_internal!(@array [$($elems,)* $crate::expr_internal!(false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        $crate::expr_internal!(@array [$($elems,)* $crate::expr_internal!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        $crate::expr_internal!(@array [$($elems,)* $crate::expr_internal!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        $crate::expr_internal!(@array [$($elems,)* $crate::expr_internal!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        $crate::expr_internal!(@array [$($elems,)* $crate::expr_internal!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        $crate::expr_internal!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        $crate::expr_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: expr_internal!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        $crate::expr_internal!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        $crate::expr_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (= null $($rest:tt)*) $copy:tt) => {
+        $crate::expr_internal!(@object $object [$($key)+] ($crate::expr_internal!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (= true $($rest:tt)*) $copy:tt) => {
+        $crate::expr_internal!(@object $object [$($key)+] ($crate::expr_internal!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (= false $($rest:tt)*) $copy:tt) => {
+        $crate::expr_internal!(@object $object [$($key)+] ($crate::expr_internal!(false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (= [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        $crate::expr_internal!(@object $object [$($key)+] ($crate::expr_internal!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (= {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        $crate::expr_internal!(@object $object [$($key)+] ($crate::expr_internal!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (= $value:expr , $($rest:tt)*) $copy:tt) => {
+        $crate::expr_internal!(@object $object [$($key)+] ($crate::expr_internal!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (= $value:expr) $copy:tt) => {
+        $crate::expr_internal!(@object $object [$($key)+] ($crate::expr_internal!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (=) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        $crate::expr_internal!();
+    };
+
+    // Missing equals and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        $crate::expr_internal!();
+    };
+
+    // Misplaced equals. Trigger a reasonable error message.
+    (@object $object:ident () (= $($rest:tt)*) ($equals:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        $crate::expr_unexpected!($equals);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        $crate::expr_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) = $($rest:tt)*) $copy:tt) => {
+        $crate::expr_internal!(@object $object ($key) (= $($rest)*) (= $($rest)*));
+    };
+
+    // Refuse to absorb equals token into key expression.
+    (@object $object:ident ($($key:tt)*) (= $($unexpected:tt)+) $copy:tt) => {
+        $crate::expr_expect_expr_comma!($($unexpected)+);
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        $crate::expr_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: expr_internal!($($expr)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        $crate::Expression::Null
+    };
+
+    (true) => {
+        $crate::Expression::Bool(true)
+    };
+
+    (false) => {
+        $crate::Expression::Bool(false)
+    };
+
+    ([]) => {
+        $crate::Expression::Array(std::vec![])
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::Expression::Array($crate::expr_internal!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        $crate::Expression::Object($crate::Object::new())
+    };
+
+    ({ $($tt:tt)+ }) => {
+        $crate::Expression::Object({
+            let mut object = $crate::Object::new();
+            $crate::expr_internal!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($other:expr) => {
+        $crate::to_expression(&$other).unwrap()
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! expr_unexpected {
+    () => {};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! expr_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,18 +24,39 @@
 ///
 /// Heredocs are not supported by the `hcl::body` macro.
 ///
+/// ## Related macros
+///
+/// The `body!` macro is composed out of different other macros that can be used on their own to
+/// construct HCL data structures:
+///
+/// - [`attribute!`]: constructs an [`Attribute`][Attribute]
+/// - [`block!`]: constructs a [`Block`][Block]
+/// - [`block_label!`]: constructs a [`BlockLabel`][BlockLabel]
+/// - [`expression!`]: constructs an [`Expression`][Expression]
+/// - [`object_key!`]: constructs an [`ObjectKey`][ObjectKey]
+/// - [`structure!`]: constructs a [`Structure`][Structure]
+///
+/// [Attribute]: ./struct.Attribute.html
+/// [Block]: ./struct.Block.html
+/// [BlockLabel]: ./enum.BlockLabel.html
+/// [Expression]: ./enum.Expression.html
+/// [ObjectKey]: ./enum.ObjectKey.html
+/// [Structure]: ./enum.Structure.html
+///
 /// ## Examples
 ///
 /// ```
+/// use hcl::{Block, Body};
+///
 /// let body = hcl::body!({
 ///     resource "aws_sns_topic" "topic" {
 ///         name = "my-topic"
 ///     }
 /// });
 ///
-/// let expected = hcl::Body::builder()
+/// let expected = Body::builder()
 ///     .add_block(
-///         hcl::Block::builder("resource")
+///         Block::builder("resource")
 ///             .add_label("aws_sns_topic")
 ///             .add_label("topic")
 ///             .add_attribute(("name", "my-topic"))
@@ -172,6 +193,10 @@ macro_rules! body_internal {
 
 /// Construct an `hcl::Structure` which may be either an HCL attribute or block.
 ///
+/// For supported syntax see the [`body!`] macro documentation.
+///
+/// ## Examples
+///
 /// ```
 /// use hcl::{Attribute, Block, Structure};
 ///
@@ -223,6 +248,10 @@ macro_rules! structure_internal {
 
 /// Construct an `hcl::Attribute` from a key and a value expression.
 ///
+/// For supported syntax see the [`body!`] macro documentation.
+///
+/// ## Examples
+///
 /// ```
 /// use hcl::Attribute;
 ///
@@ -259,6 +288,10 @@ macro_rules! attribute_internal {
 }
 
 /// Construct an `hcl::Block` from a block identifier, optional block labels and a block body.
+///
+/// For supported syntax see the [`body!`] macro documentation.
+///
+/// ## Examples
 ///
 /// ```
 /// use hcl::Block;
@@ -328,6 +361,10 @@ macro_rules! block_internal {
 
 /// Construct an `hcl::BlockLabel`.
 ///
+/// For supported syntax see the [`body!`] macro documentation.
+///
+/// ## Examples
+///
 /// ```
 /// use hcl::BlockLabel;
 ///
@@ -339,7 +376,6 @@ macro_rules! block_internal {
 /// assert_eq!(hcl::block_label!((label)), BlockLabel::string("some expression"));
 /// ```
 #[macro_export]
-#[doc(hidden)]
 macro_rules! block_label {
     ($ident:ident) => {
         $crate::BlockLabel::Identifier(std::stringify!($ident).into())
@@ -356,6 +392,10 @@ macro_rules! block_label {
 
 /// Construct an `hcl::ObjectKey`.
 ///
+/// For supported syntax see the [`body!`] macro documentation.
+///
+/// ## Examples
+///
 /// ```
 /// use hcl::ObjectKey;
 ///
@@ -367,7 +407,6 @@ macro_rules! block_label {
 /// assert_eq!(hcl::object_key!((key)), ObjectKey::string("some expression"));
 /// ```
 #[macro_export]
-#[doc(hidden)]
 macro_rules! object_key {
     ($ident:ident) => {
         $crate::ObjectKey::Identifier(std::stringify!($ident).into())
@@ -387,6 +426,10 @@ macro_rules! object_key {
 }
 
 /// Construct an `hcl::Expression` from an HCL attribute value expression literal.
+///
+/// For supported syntax see the [`body!`] macro documentation.
+///
+/// ## Examples
 ///
 /// ```
 /// use hcl::{Expression, Object, ObjectKey};

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -50,6 +50,7 @@ mod block;
 mod body;
 pub(crate) mod de;
 mod expression;
+pub(crate) mod ser;
 #[cfg(test)]
 mod tests;
 

--- a/src/structure/ser.rs
+++ b/src/structure/ser.rs
@@ -1,0 +1,446 @@
+use crate::{serialize_unsupported, Error, Expression, Object, ObjectKey, Result};
+use serde::ser::{self, Impossible};
+use std::fmt::Display;
+
+pub struct ExpressionSerializer;
+
+impl ser::Serializer for ExpressionSerializer {
+    type Ok = Expression;
+    type Error = Error;
+
+    type SerializeSeq = SerializeExpressionSeq;
+    type SerializeTuple = SerializeExpressionSeq;
+    type SerializeTupleStruct = SerializeExpressionSeq;
+    type SerializeTupleVariant = SerializeExpressionTupleVariant;
+    type SerializeMap = SerializeExpressionMap;
+    type SerializeStruct = SerializeExpressionMap;
+    type SerializeStructVariant = SerializeExpressionStructVariant;
+
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok> {
+        Ok(Expression::Bool(value))
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok> {
+        Ok(Expression::Number(value.into()))
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok> {
+        self.serialize_u64(value as u64)
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok> {
+        self.serialize_u64(value as u64)
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok> {
+        self.serialize_u64(value as u64)
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok> {
+        Ok(Expression::Number(value.into()))
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<Self::Ok> {
+        self.serialize_f64(value as f64)
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<Self::Ok> {
+        Ok(Expression::Number(value.into()))
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok> {
+        let mut s = String::new();
+        s.push(value);
+        Ok(Expression::String(s))
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok> {
+        Ok(Expression::String(value.to_owned()))
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok> {
+        let vec = value
+            .iter()
+            .map(|&b| Expression::Number(b.into()))
+            .collect();
+        Ok(Expression::Array(vec))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok> {
+        Ok(Expression::Null)
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let mut values = Object::new();
+        values.insert(ObjectKey::string(variant), to_expression(&value)?);
+        Ok(Expression::Object(values))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok> {
+        self.serialize_unit()
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(SerializeExpressionSeq {
+            vec: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Ok(SerializeExpressionTupleVariant {
+            name: String::from(variant),
+            vec: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Ok(SerializeExpressionMap {
+            map: Object::new(),
+            next_key: None,
+        })
+    }
+
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Ok(SerializeExpressionStructVariant {
+            name: String::from(variant),
+            map: Object::new(),
+        })
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Display,
+    {
+        Ok(Expression::String(value.to_string()))
+    }
+}
+pub struct SerializeExpressionSeq {
+    vec: Vec<Expression>,
+}
+
+impl ser::SerializeSeq for SerializeExpressionSeq {
+    type Ok = Expression;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.vec.push(to_expression(&value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(Expression::Array(self.vec))
+    }
+}
+
+impl ser::SerializeTuple for SerializeExpressionSeq {
+    type Ok = Expression;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl serde::ser::SerializeTupleStruct for SerializeExpressionSeq {
+    type Ok = Expression;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+pub struct SerializeExpressionTupleVariant {
+    name: String,
+    vec: Vec<Expression>,
+}
+
+impl ser::SerializeTupleVariant for SerializeExpressionTupleVariant {
+    type Ok = Expression;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.vec.push(to_expression(&value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        let mut object = Object::new();
+
+        object.insert(ObjectKey::string(self.name), Expression::Array(self.vec));
+
+        Ok(Expression::Object(object))
+    }
+}
+
+pub struct SerializeExpressionMap {
+    map: Object<ObjectKey, Expression>,
+    next_key: Option<ObjectKey>,
+}
+
+impl ser::SerializeMap for SerializeExpressionMap {
+    type Ok = Expression;
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.next_key = Some(key.serialize(ObjectKeySerializer)?);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let key = self.next_key.take();
+        let key = key.expect("serialize_value called before serialize_key");
+        self.map.insert(key, to_expression(&value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(Expression::Object(self.map))
+    }
+}
+
+impl ser::SerializeStruct for SerializeExpressionMap {
+    type Ok = Expression;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        ser::SerializeMap::serialize_entry(self, key, value)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        ser::SerializeMap::end(self)
+    }
+}
+
+pub struct SerializeExpressionStructVariant {
+    name: String,
+    map: Object<ObjectKey, Expression>,
+}
+
+impl ser::SerializeStructVariant for SerializeExpressionStructVariant {
+    type Ok = Expression;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.map
+            .insert(ObjectKey::string(key), to_expression(&value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        let mut object = Object::new();
+
+        object.insert(ObjectKey::string(self.name), Expression::Object(self.map));
+
+        Ok(Expression::Object(object))
+    }
+}
+
+struct ObjectKeySerializer;
+
+impl ser::Serializer for ObjectKeySerializer {
+    type Ok = ObjectKey;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<ObjectKey, Error>;
+    type SerializeTuple = Impossible<ObjectKey, Error>;
+    type SerializeTupleStruct = Impossible<ObjectKey, Error>;
+    type SerializeTupleVariant = Impossible<ObjectKey, Error>;
+    type SerializeMap = Impossible<ObjectKey, Error>;
+    type SerializeStruct = Impossible<ObjectKey, Error>;
+    type SerializeStructVariant = Impossible<ObjectKey, Error>;
+
+    serialize_unsupported! {
+        bool f32 f64 bytes unit unit_struct newtype_variant none
+        some seq tuple tuple_struct tuple_variant map struct struct_variant
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(ObjectKey::string(value))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok> {
+        Ok(ObjectKey::identifier(variant))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Display,
+    {
+        Ok(ObjectKey::String(value.to_string()))
+    }
+}
+
+/// Convert a `T` into `hcl::Expression` which is an enum that can represent any valid HCL
+/// attribute value.
+///
+/// # Errors
+///
+/// This conversion can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+pub fn to_expression<T>(value: T) -> Result<Expression>
+where
+    T: ser::Serialize,
+{
+    value.serialize(ExpressionSerializer)
+}

--- a/src/structure/ser.rs
+++ b/src/structure/ser.rs
@@ -61,9 +61,7 @@ impl ser::Serializer for ExpressionSerializer {
     }
 
     fn serialize_char(self, value: char) -> Result<Self::Ok> {
-        let mut s = String::new();
-        s.push(value);
-        Ok(Expression::String(s))
+        Ok(Expression::String(value.to_string()))
     }
 
     fn serialize_str(self, value: &str) -> Result<Self::Ok> {
@@ -112,9 +110,9 @@ impl ser::Serializer for ExpressionSerializer {
     where
         T: ?Sized + ser::Serialize,
     {
-        let mut values = Object::new();
-        values.insert(ObjectKey::string(variant), to_expression(&value)?);
-        Ok(Expression::Object(values))
+        let mut object = Object::new();
+        object.insert(ObjectKey::string(variant), to_expression(&value)?);
+        Ok(Expression::Object(object))
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
@@ -154,7 +152,7 @@ impl ser::Serializer for ExpressionSerializer {
         len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
         Ok(SerializeExpressionTupleVariant {
-            name: String::from(variant),
+            name: variant.to_owned(),
             vec: Vec::with_capacity(len),
         })
     }
@@ -178,7 +176,7 @@ impl ser::Serializer for ExpressionSerializer {
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         Ok(SerializeExpressionStructVariant {
-            name: String::from(variant),
+            name: variant.to_owned(),
             map: Object::new(),
         })
     }
@@ -262,9 +260,7 @@ impl ser::SerializeTupleVariant for SerializeExpressionTupleVariant {
 
     fn end(self) -> Result<Self::Ok> {
         let mut object = Object::new();
-
-        object.insert(ObjectKey::string(self.name), Expression::Array(self.vec));
-
+        object.insert(ObjectKey::String(self.name), Expression::Array(self.vec));
         Ok(Expression::Object(object))
     }
 }
@@ -337,9 +333,7 @@ impl ser::SerializeStructVariant for SerializeExpressionStructVariant {
 
     fn end(self) -> Result<Self::Ok> {
         let mut object = Object::new();
-
-        object.insert(ObjectKey::string(self.name), Expression::Object(self.map));
-
+        object.insert(ObjectKey::String(self.name), Expression::Object(self.map));
         Ok(Expression::Object(object))
     }
 }
@@ -363,43 +357,43 @@ impl ser::Serializer for ObjectKeySerializer {
         some seq tuple tuple_struct tuple_variant map struct struct_variant
     }
 
-    fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok> {
         Ok(ObjectKey::String(value.to_string()))
     }
 
-    fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok> {
         Ok(ObjectKey::String(value.to_string()))
     }
 
-    fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok> {
         Ok(ObjectKey::String(value.to_string()))
     }
 
-    fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok> {
         Ok(ObjectKey::String(value.to_string()))
     }
 
-    fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok> {
         Ok(ObjectKey::String(value.to_string()))
     }
 
-    fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok> {
         Ok(ObjectKey::String(value.to_string()))
     }
 
-    fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok> {
         Ok(ObjectKey::String(value.to_string()))
     }
 
-    fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok> {
         Ok(ObjectKey::String(value.to_string()))
     }
 
-    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+    fn serialize_char(self, value: char) -> Result<Self::Ok> {
         Ok(ObjectKey::String(value.to_string()))
     }
 
-    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+    fn serialize_str(self, value: &str) -> Result<Self::Ok> {
         Ok(ObjectKey::string(value))
     }
 
@@ -412,18 +406,14 @@ impl ser::Serializer for ObjectKeySerializer {
         Ok(ObjectKey::identifier(variant))
     }
 
-    fn serialize_newtype_struct<T>(
-        self,
-        _name: &'static str,
-        value: &T,
-    ) -> Result<Self::Ok, Self::Error>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
     where
         T: ?Sized + ser::Serialize,
     {
         value.serialize(self)
     }
 
-    fn collect_str<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok>
     where
         T: ?Sized + Display,
     {
@@ -432,7 +422,7 @@ impl ser::Serializer for ObjectKeySerializer {
 }
 
 /// Convert a `T` into `hcl::Expression` which is an enum that can represent any valid HCL
-/// attribute value.
+/// attribute value expression.
 ///
 /// # Errors
 ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,134 @@
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn expr_macro_primitives() {
+    assert_eq!(expr!(null), Expression::Null);
+    assert_eq!(expr!(true), Expression::Bool(true));
+    assert_eq!(expr!(false), Expression::Bool(false));
+    assert_eq!(expr!(0), Expression::Number(Number::from(0)));
+    assert_eq!(expr!(1.5), Expression::Number(Number::from(1.5)));
+    assert_eq!(expr!("foo"), Expression::String("foo".into()));
+}
+
+#[test]
+fn expr_macro_arrays() {
+    assert_eq!(
+        expr!(["foo", 42]),
+        Expression::Array(vec![
+            Expression::String("foo".into()),
+            Expression::Number(Number::from(42))
+        ])
+    );
+}
+
+#[test]
+fn expr_macro_objects() {
+    let expected = Expression::Object({
+        let mut object = Object::new();
+        object.insert("foo".into(), "bar".into());
+        object.insert("baz".into(), true.into());
+        object.insert("qux".into(), vec![1, 2, 3].into());
+        object
+    });
+
+    assert_eq!(
+        expr!({
+            "foo" = "bar",
+            "baz" = true,
+            "qux" = [1, 2, 3]
+        }),
+        expected
+    );
+}
+
+#[test]
+fn attr_macro() {
+    assert_eq!(
+        attr!(foo = {}),
+        Attribute::new("foo", Expression::Object(Object::new()))
+    );
+
+    let foo = "bar";
+
+    assert_eq!(
+        attr!((foo) = {}),
+        Attribute::new("bar", Expression::Object(Object::new()))
+    );
+}
+
+#[test]
+fn block_macro() {
+    assert_eq!(block!(foo {}), Block::builder("foo").build());
+    assert_eq!(
+        block!(resource "aws_s3_bucket" "bucket" {}),
+        Block::builder("resource")
+            .add_label(BlockLabel::string("aws_s3_bucket"))
+            .add_label(BlockLabel::string("bucket"))
+            .build()
+    );
+
+    assert_eq!(
+        block!(resource aws_s3_bucket bucket {}),
+        Block::builder("resource")
+            .add_label(BlockLabel::identifier("aws_s3_bucket"))
+            .add_label(BlockLabel::identifier("bucket"))
+            .build()
+    );
+
+    let ident = "resource";
+    let name = "bucket";
+
+    assert_eq!(
+        block!((ident) aws_s3_bucket (name) {}),
+        Block::builder("resource")
+            .add_label(BlockLabel::identifier("aws_s3_bucket"))
+            .add_label(BlockLabel::string("bucket"))
+            .build()
+    );
+}
+
+#[test]
+fn body_macro() {
+    assert_eq!(body!({}), Body::builder().build());
+    assert_eq!(
+        body!({
+            foo = "bar"
+            baz = "qux"
+            qux "foo" {
+                bar = 42
+            }
+        }),
+        Body::builder()
+            .add_attribute(("foo", "bar"))
+            .add_attribute(("baz", "qux"))
+            .add_block(
+                Block::builder("qux")
+                    .add_label("foo")
+                    .add_attribute(("bar", 42))
+                    .build()
+            )
+            .build()
+    );
+}
+
+#[test]
+fn structure_macro() {
+    let foo = "bar";
+    assert_eq!(
+        structure!(foo {}),
+        Structure::Block(Block::builder("foo").build())
+    );
+    assert_eq!(
+        structure!((foo) {}),
+        Structure::Block(Block::builder("bar").build())
+    );
+    assert_eq!(
+        structure!(foo = "bar"),
+        Structure::Attribute(Attribute::new("foo", "bar"))
+    );
+    assert_eq!(
+        structure!((foo) = "bar"),
+        Structure::Attribute(Attribute::new("bar", "bar"))
+    );
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,18 +3,18 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn expr_macro_primitives() {
-    assert_eq!(expr!(null), Expression::Null);
-    assert_eq!(expr!(true), Expression::Bool(true));
-    assert_eq!(expr!(false), Expression::Bool(false));
-    assert_eq!(expr!(0), Expression::Number(Number::from(0)));
-    assert_eq!(expr!(1.5), Expression::Number(Number::from(1.5)));
-    assert_eq!(expr!("foo"), Expression::String("foo".into()));
+    assert_eq!(expression!(null), Expression::Null);
+    assert_eq!(expression!(true), Expression::Bool(true));
+    assert_eq!(expression!(false), Expression::Bool(false));
+    assert_eq!(expression!(0), Expression::Number(Number::from(0)));
+    assert_eq!(expression!(1.5), Expression::Number(Number::from(1.5)));
+    assert_eq!(expression!("foo"), Expression::String("foo".into()));
 }
 
 #[test]
 fn expr_macro_arrays() {
     assert_eq!(
-        expr!(["foo", 42]),
+        expression!(["foo", 42]),
         Expression::Array(vec![
             Expression::String("foo".into()),
             Expression::Number(Number::from(42))
@@ -33,7 +33,7 @@ fn expr_macro_objects() {
     });
 
     assert_eq!(
-        expr!({
+        expression!({
             "foo" = "bar",
             "baz" = true,
             "qux" = [1, 2, 3]
@@ -43,16 +43,16 @@ fn expr_macro_objects() {
 }
 
 #[test]
-fn attr_macro() {
+fn attribute_macro() {
     assert_eq!(
-        attr!(foo = {}),
+        attribute!(foo = {}),
         Attribute::new("foo", Expression::Object(Object::new()))
     );
 
     let foo = "bar";
 
     assert_eq!(
-        attr!((foo) = {}),
+        attribute!((foo) = {}),
         Attribute::new("bar", Expression::Object(Object::new()))
     );
 }
@@ -91,11 +91,12 @@ fn block_macro() {
 #[test]
 fn body_macro() {
     assert_eq!(body!({}), Body::builder().build());
+    let bar = "foo";
     assert_eq!(
         body!({
             foo = "bar"
             baz = "qux"
-            qux "foo" {
+            qux "foo" (bar) {
                 bar = 42
             }
         }),
@@ -104,6 +105,7 @@ fn body_macro() {
             .add_attribute(("baz", "qux"))
             .add_block(
                 Block::builder("qux")
+                    .add_label("foo")
                     .add_label("foo")
                     .add_attribute(("bar", 42))
                     .build()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use pretty_assertions::assert_eq;
 
 #[test]
-fn expr_macro_primitives() {
+fn expression_macro_primitives() {
     assert_eq!(expression!(null), Expression::Null);
     assert_eq!(expression!(true), Expression::Bool(true));
     assert_eq!(expression!(false), Expression::Bool(false));
@@ -12,7 +12,7 @@ fn expr_macro_primitives() {
 }
 
 #[test]
-fn expr_macro_arrays() {
+fn expression_macro_arrays() {
     assert_eq!(
         expression!(["foo", 42]),
         Expression::Array(vec![
@@ -23,7 +23,7 @@ fn expr_macro_arrays() {
 }
 
 #[test]
-fn expr_macro_objects() {
+fn expression_macro_objects() {
     let expected = Expression::Object({
         let mut object = Object::new();
         object.insert("foo".into(), "bar".into());
@@ -40,13 +40,32 @@ fn expr_macro_objects() {
         }),
         expected
     );
+
+    let expected = Expression::Object({
+        let mut object = Object::new();
+        object.insert(ObjectKey::identifier("foo"), "bar".into());
+        object.insert("bar".into(), true.into());
+        object.insert(ObjectKey::raw_expression("qux"), vec![1, 2, 3].into());
+        object
+    });
+
+    let baz = "bar";
+
+    assert_eq!(
+        expression!({
+            foo = (baz)
+            (baz) = true
+            #{"qux"} = [1, 2, 3]
+        }),
+        expected
+    );
 }
 
 #[test]
 fn attribute_macro() {
     assert_eq!(
-        attribute!(foo = {}),
-        Attribute::new("foo", Expression::Object(Object::new()))
+        attribute!(foo = 1),
+        Attribute::new("foo", Expression::Number(1.into()))
     );
 
     let foo = "bar";
@@ -132,5 +151,9 @@ fn structure_macro() {
     assert_eq!(
         structure!((foo) = "bar"),
         Structure::Attribute(Attribute::new("bar", "bar"))
+    );
+    assert_eq!(
+        structure!((foo) = #{"raw"}),
+        Structure::Attribute(Attribute::new("bar", RawExpression::new("raw")))
     );
 }


### PR DESCRIPTION
Adds some macros to ease building HCL data structures and an `ExpressionSerializer` which is used inside the `expression!` macro.