### PR TITLE
fix: parse negate operations on numbers as negative numbers

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -1,5 +1,6 @@
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{self, Display};
+use std::ops::Neg;
 
 /// Represents a HCL number.
 #[derive(Debug, PartialEq, Clone)]
@@ -174,5 +175,24 @@ impl<'de> Deserialize<'de> for Number {
         }
 
         deserializer.deserialize_any(NumberVisitor)
+    }
+}
+
+impl Neg for Number {
+    type Output = Number;
+
+    fn neg(self) -> Self::Output {
+        match self {
+            Number::PosInt(value) => Number::NegInt(-(value as i64)),
+            Number::NegInt(value) => {
+                let value = -value;
+                if value < 0 {
+                    Number::NegInt(value)
+                } else {
+                    Number::PosInt(value as u64)
+                }
+            }
+            Number::Float(value) => Number::Float(-value),
+        }
     }
 }

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -36,8 +36,8 @@ Null    =  { "null" }
 
 // Numeric literals
 NumericLit = _{ Float | Int }
-Float      = @{ "-"? ~ Decimal+ ~ (("." ~ Decimal+ ~ (ExpMark ~ Decimal+)?) | (ExpMark ~ Decimal+)) }
-Int        = @{ "-"? ~ Decimal+ }
+Float      = @{ Decimal+ ~ (("." ~ Decimal+ ~ (ExpMark ~ Decimal+)?) | (ExpMark ~ Decimal+)) }
+Int        = @{ Decimal+ }
 ExpMark    =  { ("e" | "E") ~ ("+" | "-")? }
 Decimal    =  { '0'..'9' }
 
@@ -127,7 +127,8 @@ FullSplat =  { "[*]" }
 
 // Operations
 Operation          = { UnaryOp | BinaryOp }
-UnaryOp            = { ("-" | "!") ~ Expression }
+UnaryOp            = { UnaryOperator ~ Expression }
+UnaryOperator      = { "-" | "!" }
 BinaryOp           = { ExprTerm ~ BinaryOperator ~ Expression }
 BinaryOperator     = { CompareOperator | ArithmeticOperator | LogicOperator }
 CompareOperator    = { "==" | "!=" | "<=" | ">=" | "<" | ">" }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -32,10 +32,10 @@ fn parse_string() {
 fn parse_number() {
     parses_to! {
         parser: HclParser,
-        input: "-12e+10",
+        input: "12e+10",
         rule: Rule::NumericLit,
         tokens: [
-            Float(0, 7)
+            Float(0, 6)
         ]
     };
 
@@ -563,6 +563,25 @@ fn unescape_strings() {
                 .add_attribute(("heredoc", "some string with escaped newline\n"))
                 .build(),
         )
+        .build();
+
+    assert_eq!(body, expected);
+}
+
+#[test]
+fn negative_numbers() {
+    let input = r#"
+        float = -4.2
+        float_exp = -4.2e10
+        signed = -42
+    "#;
+
+    let body = parse(input).unwrap();
+
+    let expected = Body::builder()
+        .add_attribute(("float", -4.2f64))
+        .add_attribute(("float_exp", -4.2e10f64))
+        .add_attribute(("signed", -42))
         .build();
 
     assert_eq!(body, expected);


### PR DESCRIPTION
The HCL spec does not specify negative numbers and represents them as
negate operations on positive integers and floats.

This change updates the parser to peek into unary operations and promote
negations on numbers to negative numbers instead. This behaviour will
most likely be kept even after adding the `Operation` variant to the
`Expression` type at one point.