### PR TITLE
chore(deps): bump pest from 2.1.3 to 2.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ path = "specsuite/main.rs"
 harness = false
 
 [dependencies]
-pest = "2.1.3"
-pest_derive = "2.1.0"
+pest = "2.2.1"
+pest_derive = "2.2.1"
 itoa = "1.0.1"
 ryu = "1.0.9"
 unicode-ident = "1.0.0"

--- a/specsuite/hcl/invalid-heredoc.hcl.json
+++ b/specsuite/hcl/invalid-heredoc.hcl.json
@@ -1,8 +1,6 @@
 {
   "message": "EOF must be immediately followed by a newline",
-  "ignore": true,
   "body": {
-    "comment": "The line feed char after the word `invalid` is present locally, somehow stop showing up in GitHub actions. Needs investigation.",
-    "message": " --> 2:12\n  |\n2 |   source = <<-EOF # This is invalid␊\n  |            ^---\n  |\n  = expected ExprTerm, Operation, or CondExpr"
+    "message": " --> 2:12\n  |\n2 |   source = <<-EOF # This is invalid\n  |            ^---\n  |\n  = expected ExprTerm, Operation, or CondExpr"
   }
 }


### PR DESCRIPTION
This also allows us to reenable an ignored test.