### PR TITLE
feat: add `Expression::ElementAccess`

### DIFF
--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{Block, Body, Expression, ObjectKey, RawExpression};
+use crate::{Block, Body, ElementAccess, Expression, Identifier, ObjectKey};
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -235,7 +235,11 @@ fn deserialize_terraform() {
                                     Block::builder("apply_server_side_encryption_by_default")
                                         .add_attribute((
                                             "kms_master_key_id",
-                                            RawExpression::new("aws_kms_key.mykey.arn"),
+                                            ElementAccess::new(
+                                                Identifier::new("aws_kms_key"),
+                                                "mykey",
+                                            )
+                                            .chain("arn"),
                                         ))
                                         .add_attribute(("sse_algorithm", "aws:kms"))
                                         .build(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,9 @@ pub use parser::parse;
 pub use ser::{to_string, to_vec, to_writer};
 #[doc(inline)]
 pub use structure::{
-    ser::to_expression, Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder, Expression,
-    Heredoc, HeredocStripMode, Identifier, Object, ObjectKey, RawExpression, Structure,
-    TemplateExpr,
+    ser::to_expression, Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder,
+    ElementAccess, ElementAccessOperator, Expression, Heredoc, HeredocStripMode, Identifier,
+    Object, ObjectKey, RawExpression, Structure, TemplateExpr,
 };
 #[doc(inline)]
 pub use value::{Map, Value};

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::{ElementAccess, Identifier};
 use pest::*;
 use pretty_assertions::assert_eq;
 
@@ -565,7 +566,11 @@ fn parse_hcl() {
                                     Block::builder("apply_server_side_encryption_by_default")
                                         .add_attribute(Attribute::new(
                                             "kms_master_key_id",
-                                            RawExpression::new("aws_kms_key.mykey.arn"),
+                                            ElementAccess::new(
+                                                Identifier::new("aws_kms_key"),
+                                                "mykey",
+                                            )
+                                            .chain("arn"),
                                         ))
                                         .add_attribute(Attribute::new("sse_algorithm", "aws:kms"))
                                         .build(),

--- a/src/structure/element_access.rs
+++ b/src/structure/element_access.rs
@@ -1,0 +1,80 @@
+use crate::{Expression, Identifier};
+use serde::{Deserialize, Serialize};
+
+/// Access to an element of an expression result.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename = "$hcl::element_access")]
+pub struct ElementAccess {
+    /// The expression that the access operator is applied to.
+    pub expr: Expression,
+    /// The element access operator used on the expression.
+    pub operator: ElementAccessOperator,
+}
+
+impl ElementAccess {
+    /// Creates a new `ElementAccess` structure from an access operator and and expression that it
+    /// should be applied to.
+    pub fn new<E, O>(expr: E, operator: O) -> Self
+    where
+        E: Into<Expression>,
+        O: Into<ElementAccessOperator>,
+    {
+        ElementAccess {
+            expr: expr.into(),
+            operator: operator.into(),
+        }
+    }
+
+    /// Chains another `ElementAccessOperator` and returns a new `ElementAccess`.
+    pub fn chain<O>(self, operator: O) -> ElementAccess
+    where
+        O: Into<ElementAccessOperator>,
+    {
+        ElementAccess {
+            expr: Expression::ElementAccess(Box::new(self)),
+            operator: operator.into(),
+        }
+    }
+}
+
+/// The kinds of element access that are supported by HCL.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename = "$hcl::element_access_operator")]
+pub enum ElementAccessOperator {
+    /// The attribute-only splat operator supports only attribute lookups into the elements from a
+    /// list, but supports an arbitrary number of them.
+    AttrSplat,
+    /// The full splat operator additionally supports indexing into the elements from a list, and
+    /// allows any combination of attribute access and index operations.
+    FullSplat,
+    /// The attribute access operator returns the value of a single attribute in an object value.
+    GetAttr(Identifier),
+    /// The index operator returns the value of a single element of a collection value based on
+    /// the result of the expression.
+    Index(Expression),
+    /// The legacy index operator returns the value of a single element of a collection value.
+    /// Exists only for compatibility with the precursor language HIL. Use the `Index` variant
+    /// instead.
+    LegacyIndex(u64),
+}
+
+impl<T> From<T> for ElementAccessOperator
+where
+    T: Into<Identifier>,
+{
+    fn from(value: T) -> ElementAccessOperator {
+        ElementAccessOperator::GetAttr(value.into())
+    }
+}
+
+impl From<Expression> for ElementAccessOperator {
+    fn from(value: Expression) -> ElementAccessOperator {
+        ElementAccessOperator::Index(value)
+    }
+}
+
+impl From<u64> for ElementAccessOperator {
+    fn from(value: u64) -> ElementAccessOperator {
+        ElementAccessOperator::LegacyIndex(value)
+    }
+}

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -49,6 +49,7 @@ mod attribute;
 mod block;
 mod body;
 pub(crate) mod de;
+mod element_access;
 mod expression;
 pub(crate) mod ser;
 mod template;
@@ -59,6 +60,7 @@ pub use self::{
     attribute::Attribute,
     block::{Block, BlockBuilder, BlockLabel},
     body::{Body, BodyBuilder},
+    element_access::{ElementAccess, ElementAccessOperator},
     expression::{Expression, Object, ObjectKey, RawExpression},
     template::{Heredoc, HeredocStripMode, TemplateExpr},
 };

--- a/src/structure/ser/element_access.rs
+++ b/src/structure/ser/element_access.rs
@@ -1,0 +1,150 @@
+use super::{expression::ExpressionSerializer, StringSerializer};
+use crate::{
+    serialize_unsupported, structure::Identifier, ElementAccess, ElementAccessOperator, Error,
+    Expression, Result,
+};
+use serde::ser::{self, Impossible, Serialize};
+
+pub struct ElementAccessSerializer;
+
+impl ser::Serializer for ElementAccessSerializer {
+    type Ok = ElementAccess;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<ElementAccess, Error>;
+    type SerializeTuple = Impossible<ElementAccess, Error>;
+    type SerializeTupleStruct = Impossible<ElementAccess, Error>;
+    type SerializeTupleVariant = Impossible<ElementAccess, Error>;
+    type SerializeMap = Impossible<ElementAccess, Error>;
+    type SerializeStruct = SerializeElementAccessStruct;
+    type SerializeStructVariant = Impossible<ElementAccess, Error>;
+
+    serialize_unsupported! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64
+        char str bytes none unit unit_struct unit_variant
+        newtype_variant seq tuple tuple_struct tuple_variant map struct_variant
+    }
+    serialize_self! { some newtype_struct }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(SerializeElementAccessStruct::new())
+    }
+}
+
+pub struct SerializeElementAccessStruct {
+    expr: Option<Expression>,
+    operator: Option<ElementAccessOperator>,
+}
+
+impl SerializeElementAccessStruct {
+    pub fn new() -> Self {
+        SerializeElementAccessStruct {
+            expr: None,
+            operator: None,
+        }
+    }
+}
+
+impl ser::SerializeStruct for SerializeElementAccessStruct {
+    type Ok = ElementAccess;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        match key {
+            "expr" => self.expr = Some(value.serialize(ExpressionSerializer)?),
+            "operator" => self.operator = Some(value.serialize(ElementAccessOperatorSerializer)?),
+            _ => {
+                return Err(ser::Error::custom(
+                    "expected struct with fields `expr` and `operator`",
+                ))
+            }
+        };
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        match (self.expr, self.operator) {
+            (Some(expr), Some(operator)) => Ok(ElementAccess::new(expr, operator)),
+            (_, _) => Err(ser::Error::custom(
+                "expected struct with fields `expr` and `operator`",
+            )),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ElementAccessOperatorSerializer;
+
+impl ser::Serializer for ElementAccessOperatorSerializer {
+    type Ok = ElementAccessOperator;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<ElementAccessOperator, Error>;
+    type SerializeTuple = Impossible<ElementAccessOperator, Error>;
+    type SerializeTupleStruct = Impossible<ElementAccessOperator, Error>;
+    type SerializeTupleVariant = Impossible<ElementAccessOperator, Error>;
+    type SerializeMap = Impossible<ElementAccessOperator, Error>;
+    type SerializeStruct = Impossible<ElementAccessOperator, Error>;
+    type SerializeStructVariant = Impossible<ElementAccessOperator, Error>;
+
+    serialize_unsupported! {
+        bool i8 i16 i32 i64 u8 u16 u32 f32 f64
+        char str bytes none unit unit_struct
+        seq tuple tuple_struct tuple_variant
+        map struct struct_variant
+    }
+    serialize_self! { some }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok> {
+        Ok(ElementAccessOperator::LegacyIndex(v))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok> {
+        match (name, variant) {
+            ("$hcl::element_access_operator", "AttrSplat") => Ok(ElementAccessOperator::AttrSplat),
+            ("$hcl::element_access_operator", "FullSplat") => Ok(ElementAccessOperator::FullSplat),
+            (_, _) => Ok(ElementAccessOperator::GetAttr(variant.into())),
+        }
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if name == "$hcl::expression" {
+            Ok(ElementAccessOperator::Index(
+                value.serialize(ExpressionSerializer)?,
+            ))
+        } else {
+            value.serialize(self)
+        }
+    }
+
+    fn serialize_newtype_struct<T>(self, name: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        if name == "$hcl::identifier" {
+            Ok(ElementAccessOperator::GetAttr(Identifier::from(
+                value.serialize(StringSerializer)?,
+            )))
+        } else {
+            value.serialize(self)
+        }
+    }
+}

--- a/src/structure/ser/mod.rs
+++ b/src/structure/ser/mod.rs
@@ -3,6 +3,7 @@
 mod attribute;
 mod block;
 pub(crate) mod body;
+mod element_access;
 mod expression;
 mod structure;
 mod template;


### PR DESCRIPTION
This adds supports for parsing and serializing element access on expression like `some_var.some_attribute` or `foo[0]`.