### PR TITLE
feat: add `Expression::FuncCall`

### DIFF
--- a/specsuite/hcl/terraform.hcl.json
+++ b/specsuite/hcl/terraform.hcl.json
@@ -27,7 +27,7 @@
               }
             }
           },
-          "tags": "${merge(\n    var.tags,\n    var.cluster_tags,\n  )}",
+          "tags": "${merge(var.tags, var.cluster_tags)}",
           "depends_on": [
             "${aws_cloudwatch_log_group.this}"
           ]

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{Block, Body, ElementAccess, Expression, Identifier, ObjectKey};
+use crate::{Block, Body, ElementAccess, Expression, FuncCall, Identifier, ObjectKey};
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -189,6 +189,23 @@ fn deserialize_enum() {
         value: E::Struct { a: 1 },
     };
     assert_eq!(expected, from_str::<Test>(input).unwrap());
+}
+
+#[test]
+fn deserialize_func_call() {
+    let input = r#"attr = foo(1, "bar", ["baz", "qux"]...)"#;
+    let expected = Body::builder()
+        .add_attribute((
+            "attr",
+            FuncCall::builder("foo")
+                .arg(1)
+                .arg("bar")
+                .arg(vec!["baz", "qux"])
+                .variadic(true)
+                .build(),
+        ))
+        .build();
+    assert_eq!(expected, from_str::<Body>(input).unwrap());
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@ pub use ser::{to_string, to_vec, to_writer};
 #[doc(inline)]
 pub use structure::{
     ser::to_expression, Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder,
-    ElementAccess, ElementAccessOperator, Expression, Heredoc, HeredocStripMode, Identifier,
-    Object, ObjectKey, RawExpression, Structure, TemplateExpr,
+    ElementAccess, ElementAccessOperator, Expression, FuncCall, FuncCallBuilder, Heredoc,
+    HeredocStripMode, Identifier, Object, ObjectKey, RawExpression, Structure, TemplateExpr,
 };
 #[doc(inline)]
 pub use value::{Map, Value};

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -83,7 +83,7 @@ StringPart = {
 }
 
 // Functions and function calls
-FunctionCall = @{
+FunctionCall = ${
     Identifier ~ "(" ~
     WHITESPACE* ~ (COMMENT ~ WHITESPACE*)* ~
     Arguments ~
@@ -91,7 +91,8 @@ FunctionCall = @{
     ")"
 }
 
-Arguments = !{ (Expression ~ ("," ~ Expression)* ~ ("," | "...")?)? }
+Arguments = !{ (Expression ~ ("," ~ Expression)* ~ ("," | Variadic)?)? }
+Variadic  =  { "..." }
 
 // For expressions
 ForExpr       = { ForTupleExpr | ForObjectExpr }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -421,9 +421,11 @@ fn parse_nested_function_call_with_splat() {
         rule: Rule::FunctionCall,
         tokens: [
             FunctionCall(0, 72, [
+                Identifier(0, 7),
                 Arguments(8, 71, [
                     ExprTerm(8, 68, [
                         FunctionCall(8, 68, [
+                            Identifier(8, 14),
                             Arguments(15, 67, [
                                 ExprTerm(15, 40, [
                                     VariableExpr(15, 26),

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    Block, BlockLabel, Body, ElementAccess, ElementAccessOperator, Expression, Heredoc,
+    Block, BlockLabel, Body, ElementAccess, ElementAccessOperator, Expression, FuncCall, Heredoc,
     HeredocStripMode, Identifier, Object, ObjectKey, RawExpression, TemplateExpr,
 };
 use pretty_assertions::assert_eq;
@@ -213,6 +213,37 @@ fn serialize_element_access() {
     assert_eq!(
         to_string(&body).unwrap(),
         "attr = var.foo[*].bar[1].*.baz.42\n"
+    );
+}
+
+#[test]
+fn serialize_func_call() {
+    let body = Body::builder()
+        .add_attribute(("attr", FuncCall::new("foo")))
+        .build();
+
+    assert_eq!(to_string(&body).unwrap(), "attr = foo()\n");
+
+    let body = Body::builder()
+        .add_attribute(("attr", FuncCall::builder("foo").arg(1).arg("two").build()))
+        .build();
+
+    assert_eq!(to_string(&body).unwrap(), "attr = foo(1, \"two\")\n");
+
+    let body = Body::builder()
+        .add_attribute((
+            "attr",
+            FuncCall::builder("foo")
+                .arg(1)
+                .arg(vec!["two", "three"])
+                .variadic(true)
+                .build(),
+        ))
+        .build();
+
+    assert_eq!(
+        to_string(&body).unwrap(),
+        "attr = foo(1, [\"two\", \"three\"]...)\n"
     );
 }
 

--- a/src/structure/expression.rs
+++ b/src/structure/expression.rs
@@ -1,6 +1,6 @@
 //! Types to represent HCL attribute value expressions.
 
-use super::{ElementAccess, ElementAccessOperator, Identifier, TemplateExpr};
+use super::{ElementAccess, ElementAccessOperator, FuncCall, Identifier, TemplateExpr};
 use crate::{Number, Value};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -34,6 +34,8 @@ pub enum Expression {
     VariableExpr(Identifier),
     /// Represents an attribute or element access.
     ElementAccess(Box<ElementAccess>),
+    /// Represents a function call.
+    FuncCall(Box<FuncCall>),
     /// Represents a raw HCL expression. This includes any expression kind that does match any of
     /// the enum variants above. See [`RawExpression`] for more details.
     Raw(RawExpression),
@@ -184,6 +186,12 @@ impl From<RawExpression> for Expression {
 impl From<ElementAccess> for Expression {
     fn from(access: ElementAccess) -> Self {
         Expression::ElementAccess(Box::new(access))
+    }
+}
+
+impl From<FuncCall> for Expression {
+    fn from(func_call: FuncCall) -> Self {
+        Expression::FuncCall(Box::new(func_call))
     }
 }
 

--- a/src/structure/func.rs
+++ b/src/structure/func.rs
@@ -1,0 +1,67 @@
+use crate::{Expression, Identifier};
+use serde::{Deserialize, Serialize};
+
+/// Represents a function call expression with zero or more arguments. Function calls can be
+/// variadic.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename = "$hcl::func_call")]
+pub struct FuncCall {
+    /// The name of the function.
+    pub name: Identifier,
+    /// The function arguments.
+    pub args: Vec<Expression>,
+    /// Specifies whether this is a variadic function call or not.
+    pub variadic: bool,
+}
+
+impl FuncCall {
+    /// Creates a new `FuncCall` for the function with given name.
+    pub fn new<T>(name: T) -> FuncCall
+    where
+        T: Into<Identifier>,
+    {
+        FuncCall {
+            name: name.into(),
+            args: Vec::new(),
+            variadic: false,
+        }
+    }
+
+    /// Creates a new `FuncCallBuilder` for the function with given name.
+    pub fn builder<T>(name: T) -> FuncCallBuilder
+    where
+        T: Into<Identifier>,
+    {
+        FuncCallBuilder {
+            f: FuncCall::new(name),
+        }
+    }
+}
+
+/// A builder for function calls.
+#[derive(Debug)]
+pub struct FuncCallBuilder {
+    f: FuncCall,
+}
+
+impl FuncCallBuilder {
+    /// Adds an argument to the function call.
+    pub fn arg<T>(mut self, arg: T) -> FuncCallBuilder
+    where
+        T: Into<Expression>,
+    {
+        self.f.args.push(arg.into());
+        self
+    }
+
+    /// Marks the function as variadic or not.
+    pub fn variadic(mut self, yes: bool) -> FuncCallBuilder {
+        self.f.variadic = yes;
+        self
+    }
+
+    /// Consumes the `FuncCallBuilder` and returns the `FuncCall`.
+    pub fn build(self) -> FuncCall {
+        self.f
+    }
+}

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -51,6 +51,7 @@ mod body;
 pub(crate) mod de;
 mod element_access;
 mod expression;
+mod func;
 pub(crate) mod ser;
 mod template;
 #[cfg(test)]
@@ -62,6 +63,7 @@ pub use self::{
     body::{Body, BodyBuilder},
     element_access::{ElementAccess, ElementAccessOperator},
     expression::{Expression, Object, ObjectKey, RawExpression},
+    func::{FuncCall, FuncCallBuilder},
     template::{Heredoc, HeredocStripMode, TemplateExpr},
 };
 use crate::{Map, Value};

--- a/src/structure/ser/expression.rs
+++ b/src/structure/ser/expression.rs
@@ -1,6 +1,6 @@
 use super::{
-    element_access::SerializeElementAccessStruct, template::TemplateExprSerializer,
-    StringSerializer,
+    element_access::SerializeElementAccessStruct, func::SerializeFuncCallStruct,
+    template::TemplateExprSerializer, StringSerializer,
 };
 use crate::{
     serialize_unsupported, Error, Expression, Identifier, Object, ObjectKey, RawExpression, Result,
@@ -306,6 +306,7 @@ impl ser::SerializeMap for SerializeExpressionMap {
 
 pub enum SerializeExpressionStruct {
     ElementAccess(SerializeElementAccessStruct),
+    FuncCall(SerializeFuncCallStruct),
     Other(SerializeExpressionMap),
 }
 
@@ -315,6 +316,9 @@ impl SerializeExpressionStruct {
         match name {
             "$hcl::element_access" => {
                 SerializeExpressionStruct::ElementAccess(SerializeElementAccessStruct::new())
+            }
+            "$hcl::func_call" => {
+                SerializeExpressionStruct::FuncCall(SerializeFuncCallStruct::new())
             }
             _ => SerializeExpressionStruct::Other(SerializeExpressionMap::new(Some(len))),
         }
@@ -331,6 +335,7 @@ impl ser::SerializeStruct for SerializeExpressionStruct {
     {
         match self {
             SerializeExpressionStruct::ElementAccess(ser) => ser.serialize_field(key, value),
+            SerializeExpressionStruct::FuncCall(ser) => ser.serialize_field(key, value),
             SerializeExpressionStruct::Other(ser) => ser.serialize_entry(key, value),
         }
     }
@@ -338,6 +343,7 @@ impl ser::SerializeStruct for SerializeExpressionStruct {
     fn end(self) -> Result<Self::Ok> {
         match self {
             SerializeExpressionStruct::ElementAccess(ser) => ser.end().map(Into::into),
+            SerializeExpressionStruct::FuncCall(ser) => ser.end().map(Into::into),
             SerializeExpressionStruct::Other(ser) => ser.end(),
         }
     }

--- a/src/structure/ser/func.rs
+++ b/src/structure/ser/func.rs
@@ -1,0 +1,81 @@
+use super::{expression::ExpressionSerializer, BoolSerializer, SeqSerializer, StringSerializer};
+use crate::{serialize_unsupported, Error, Expression, FuncCall, Identifier, Result};
+use serde::ser::{self, Impossible};
+
+pub struct FuncCallSerializer;
+
+impl ser::Serializer for FuncCallSerializer {
+    type Ok = FuncCall;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<FuncCall, Error>;
+    type SerializeTuple = Impossible<FuncCall, Error>;
+    type SerializeTupleStruct = Impossible<FuncCall, Error>;
+    type SerializeTupleVariant = Impossible<FuncCall, Error>;
+    type SerializeMap = Impossible<FuncCall, Error>;
+    type SerializeStruct = SerializeFuncCallStruct;
+    type SerializeStructVariant = Impossible<FuncCall, Error>;
+
+    serialize_unsupported! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64
+        char str bytes none unit unit_struct unit_variant
+        newtype_variant seq tuple tuple_struct tuple_variant map struct_variant
+    }
+    serialize_self! { some newtype_struct }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(SerializeFuncCallStruct::new())
+    }
+}
+
+pub struct SerializeFuncCallStruct {
+    name: Option<Identifier>,
+    args: Option<Vec<Expression>>,
+    variadic: Option<bool>,
+}
+
+impl SerializeFuncCallStruct {
+    pub fn new() -> Self {
+        SerializeFuncCallStruct {
+            name: None,
+            args: None,
+            variadic: None,
+        }
+    }
+}
+
+impl ser::SerializeStruct for SerializeFuncCallStruct {
+    type Ok = FuncCall;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        match key {
+            "name" => self.name = Some(Identifier::from(value.serialize(StringSerializer)?)),
+            "args" => self.args = Some(value.serialize(SeqSerializer::new(ExpressionSerializer))?),
+            "variadic" => self.variadic = Some(value.serialize(BoolSerializer)?),
+            _ => {
+                return Err(ser::Error::custom(
+                    "expected struct with fields `name`, `args` and optional `variadic`",
+                ))
+            }
+        };
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        match (self.name, self.args) {
+            (Some(name), Some(args)) => Ok(FuncCall {
+                name,
+                args,
+                variadic: self.variadic.unwrap_or_default(),
+            }),
+            (_, _) => Err(ser::Error::custom(
+                "expected struct with fields `name`, `args` and optional `variadic`",
+            )),
+        }
+    }
+}

--- a/src/structure/ser/mod.rs
+++ b/src/structure/ser/mod.rs
@@ -5,6 +5,7 @@ mod block;
 pub(crate) mod body;
 mod element_access;
 mod expression;
+mod func;
 mod structure;
 mod template;
 #[cfg(test)]
@@ -58,6 +59,32 @@ impl ser::Serializer for StringSerializer {
         T: ?Sized + Display,
     {
         Ok(value.to_string())
+    }
+}
+
+pub struct BoolSerializer;
+
+impl ser::Serializer for BoolSerializer {
+    type Ok = bool;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<bool, Error>;
+    type SerializeTuple = Impossible<bool, Error>;
+    type SerializeTupleStruct = Impossible<bool, Error>;
+    type SerializeTupleVariant = Impossible<bool, Error>;
+    type SerializeMap = Impossible<bool, Error>;
+    type SerializeStruct = Impossible<bool, Error>;
+    type SerializeStructVariant = Impossible<bool, Error>;
+
+    serialize_unsupported! {
+        i8 i16 i32 i64 u8 u16 u32 u64
+        f32 f64 char str bytes unit unit_struct unit_variant newtype_variant none
+        seq tuple tuple_struct tuple_variant map struct struct_variant
+    }
+    serialize_self! { some newtype_struct }
+
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok> {
+        Ok(value)
     }
 }
 


### PR DESCRIPTION
This adds supports for parsing and serializing function call expressions of the form `func_name(arg1, arg2...)`.