### PR TITLE
feat: add `Expression::SubExpr`

### DIFF
--- a/src/format/impls.rs
+++ b/src/format/impls.rs
@@ -108,6 +108,12 @@ impl Format for Expression {
             Expression::VariableExpr(ident) => ident.format(fmt),
             Expression::ElementAccess(access) => access.format(fmt),
             Expression::FuncCall(func_call) => func_call.format(fmt),
+            Expression::SubExpr(expr) => {
+                fmt.write_all(b"(")?;
+                expr.format(fmt)?;
+                fmt.write_all(b")")?;
+                Ok(())
+            }
         }
     }
 }

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -12,7 +12,8 @@ BlockBody = { "{" ~ Body ~ "}" }
 // Expressions
 Expression    = _{ Conditional | Operation | ExprTerm }
 ExprTerm      =  { ExprTermInner ~ (Splat | GetAttr | Index)* }
-ExprTermInner = _{ Value | TemplateExpr | FunctionCall | VariableExpr | ForExpr | ("(" ~ Expression ~ ")") }
+ExprTermInner = _{ Value | TemplateExpr | FunctionCall | VariableExpr | ForExpr | SubExpression }
+SubExpression =  { "(" ~ Expression ~ ")" }
 
 // Values
 Value = _{ LiteralValue | CollectionValue }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -173,6 +173,7 @@ fn parse_expr_term(pair: Pair<Rule>) -> Result<Expression> {
         Rule::Object => parse_object(pair).map(Expression::Object)?,
         Rule::VariableExpr => Expression::VariableExpr(parse_ident(pair).into()),
         Rule::FunctionCall => Expression::FuncCall(Box::new(parse_func_call(pair)?)),
+        Rule::SubExpression => Expression::SubExpr(Box::new(parse_expression(inner(pair))?)),
         // @TODO(mohmann): Process ForExpr etc.
         _ => Expression::Raw(raw_expression(pair.as_str())),
     };

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -347,6 +347,18 @@ qux {
 }
 
 #[test]
+fn serialize_nested_expression() {
+    let body = Body::builder()
+        .add_attribute((
+            "attr",
+            Expression::SubExpr(Box::new(Expression::VariableExpr("foo".into()))),
+        ))
+        .build();
+
+    assert_eq!(to_string(&body).unwrap(), "attr = (foo)\n");
+}
+
+#[test]
 fn roundtrip() {
     let input = Body::builder()
         .add_block(
@@ -391,7 +403,9 @@ fn roundtrip() {
                         ),
                         (
                             ObjectKey::Identifier("environment".into()),
-                            Expression::VariableExpr("environment".into()),
+                            Expression::SubExpr(Box::new(Expression::VariableExpr(
+                                "environment".into(),
+                            ))),
                         ),
                     ]),
                 ))

--- a/src/structure/de.rs
+++ b/src/structure/de.rs
@@ -267,6 +267,7 @@ impl<'de> de::Deserializer<'de> for Expression {
             Expression::FuncCall(func_call) => {
                 func_call.into_deserializer().deserialize_any(visitor)
             }
+            Expression::SubExpr(expr) => expr.into_deserializer().deserialize_any(visitor),
         }
     }
 
@@ -297,6 +298,7 @@ impl VariantName for Expression {
             Expression::VariableExpr(_) => "VariableExpr",
             Expression::ElementAccess(_) => "ElementAccess",
             Expression::FuncCall(_) => "FuncCall",
+            Expression::SubExpr(_) => "SubExpr",
         }
     }
 }
@@ -329,6 +331,7 @@ impl<'de> de::VariantAccess<'de> for Expression {
     {
         match self {
             Expression::TemplateExpr(expr) => seed.deserialize(expr.into_deserializer()),
+            Expression::SubExpr(expr) => seed.deserialize(expr.into_deserializer()),
             value => seed.deserialize(value.into_deserializer()),
         }
     }

--- a/src/structure/expression.rs
+++ b/src/structure/expression.rs
@@ -36,6 +36,8 @@ pub enum Expression {
     ElementAccess(Box<ElementAccess>),
     /// Represents a function call.
     FuncCall(Box<FuncCall>),
+    /// Represents a sub-expression that is wrapped in parenthesis.
+    SubExpr(Box<Expression>),
     /// Represents a raw HCL expression. This includes any expression kind that does match any of
     /// the enum variants above. See [`RawExpression`] for more details.
     Raw(RawExpression),
@@ -67,6 +69,7 @@ impl From<Expression> for Value {
             Expression::Array(array) => array.into_iter().collect(),
             Expression::Object(object) => object.into_iter().collect(),
             Expression::TemplateExpr(expr) => Value::String(expr.to_string()),
+            Expression::SubExpr(expr) => Value::from(*expr),
             Expression::Raw(raw) => Value::String(raw.into()),
             other => Value::String(RawExpression(other.to_string()).into()),
         }
@@ -110,6 +113,12 @@ impl From<f32> for Expression {
 impl From<f64> for Expression {
     fn from(f: f64) -> Self {
         Expression::Number(f.into())
+    }
+}
+
+impl From<Number> for Expression {
+    fn from(num: Number) -> Self {
+        Expression::Number(num)
     }
 }
 


### PR DESCRIPTION
This adds supports for parsing and serializing sub expressions (expressions wrapped in parenthesis).