### PR TITLE
feat: add `Expression::Conditional`

### DIFF
--- a/specsuite/hcl/invalid-heredoc.hcl.json
+++ b/specsuite/hcl/invalid-heredoc.hcl.json
@@ -1,6 +1,6 @@
 {
   "message": "EOF must be immediately followed by a newline",
   "body": {
-    "message": " --> 2:12\n  |\n2 |   source = <<-EOF # This is invalid\n  |            ^---\n  |\n  = expected ExprTerm, Operation, or CondExpr"
+    "message": " --> 2:12\n  |\n2 |   source = <<-EOF # This is invalid\n  |            ^---\n  |\n  = expected ExprTerm, Operation, or Conditional"
   }
 }

--- a/src/format/impls.rs
+++ b/src/format/impls.rs
@@ -1,8 +1,8 @@
 use super::{private, Format, Formatter};
 use crate::{
     structure::{
-        Attribute, Block, BlockLabel, Body, Expression, FuncCall, Heredoc, HeredocStripMode,
-        Identifier, ObjectKey, RawExpression, Structure, TemplateExpr,
+        Attribute, Block, BlockLabel, Body, Conditional, Expression, FuncCall, Heredoc,
+        HeredocStripMode, Identifier, ObjectKey, RawExpression, Structure, TemplateExpr,
     },
     ElementAccess, ElementAccessOperator, Map, Number, Result, Value,
 };
@@ -114,6 +114,7 @@ impl Format for Expression {
                 fmt.write_all(b")")?;
                 Ok(())
             }
+            Expression::Conditional(cond) => cond.format(fmt),
         }
     }
 }
@@ -312,6 +313,22 @@ impl Format for FuncCall {
             fmt.write_all(b")")?;
         }
 
+        Ok(())
+    }
+}
+
+impl private::Sealed for Conditional {}
+
+impl Format for Conditional {
+    fn format<W>(&self, fmt: &mut Formatter<W>) -> Result<()>
+    where
+        W: io::Write,
+    {
+        self.predicate.format(fmt)?;
+        fmt.write_all(b" ? ")?;
+        self.true_expr.format(fmt)?;
+        fmt.write_all(b" : ")?;
+        self.false_expr.format(fmt)?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use parser::parse;
 pub use ser::{to_string, to_vec, to_writer};
 #[doc(inline)]
 pub use structure::{
-    ser::to_expression, Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder,
+    ser::to_expression, Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder, Conditional,
     ElementAccess, ElementAccessOperator, Expression, FuncCall, FuncCallBuilder, Heredoc,
     HeredocStripMode, Identifier, Object, ObjectKey, RawExpression, Structure, TemplateExpr,
 };

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -129,8 +129,8 @@ LogicOperator      = { "&&" | "||" }
 
 
 // Conditional operator
-CondExpr    = { ExprTerm | Operation }
-Conditional = { CondExpr ~ "?" ~ Expression ~ ":" ~ Expression }
+CondExpr    = _{ ExprTerm | Operation }
+Conditional =  { CondExpr ~ "?" ~ Expression ~ ":" ~ Expression }
 
 // Comments
 COMMENT         = _{ InlineComment | BlockComment }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -77,12 +77,10 @@ fn conditional() {
         rule: Rule::Conditional,
         tokens: [
             Conditional(0, 19, [
-                CondExpr(0, 11, [
-                    ExprTerm(0, 11, [
-                        VariableExpr(0, 3),
-                        GetAttr(3, 11, [
-                            Identifier(4, 11)
-                        ])
+                ExprTerm(0, 11, [
+                    VariableExpr(0, 3),
+                    GetAttr(3, 11, [
+                        Identifier(4, 11)
                     ])
                 ]),
                 ExprTerm(14, 16, [
@@ -335,12 +333,10 @@ fn parse_cond_in_interpolation() {
                                 TemplateInterpolation(8, 36, [
                                     TemplateIExprStartNormal(8, 10),
                                     Conditional(10, 35, [
-                                        CondExpr(10, 15, [
-                                            ExprTerm(10, 15, [
-                                                VariableExpr(10, 13),
-                                                GetAttr(13, 15, [
-                                                    Identifier(14, 15)
-                                                ])
+                                        ExprTerm(10, 15, [
+                                            VariableExpr(10, 13),
+                                            GetAttr(13, 15, [
+                                                Identifier(14, 15)
                                             ])
                                         ]),
                                         ExprTerm(18, 31, [

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::{
-    Block, BlockLabel, Body, ElementAccess, ElementAccessOperator, Expression, FuncCall, Heredoc,
-    HeredocStripMode, Identifier, Object, ObjectKey, RawExpression, TemplateExpr,
+    Block, BlockLabel, Body, Conditional, ElementAccess, ElementAccessOperator, Expression,
+    FuncCall, Heredoc, HeredocStripMode, Identifier, Object, ObjectKey, RawExpression,
+    TemplateExpr,
 };
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -217,6 +218,21 @@ fn serialize_element_access() {
 }
 
 #[test]
+fn serialize_conditional() {
+    let body = Body::builder()
+        .add_attribute((
+            "cond",
+            Conditional::new(Identifier::new("cond_var"), "yes", "no"),
+        ))
+        .build();
+
+    assert_eq!(
+        to_string(&body).unwrap(),
+        "cond = cond_var ? \"yes\" : \"no\"\n"
+    );
+}
+
+#[test]
 fn serialize_func_call() {
     let body = Body::builder()
         .add_attribute(("attr", FuncCall::new("foo")))
@@ -365,6 +381,10 @@ fn roundtrip() {
             Block::builder("resource")
                 .add_label("aws_s3_bucket")
                 .add_label("mybucket")
+                .add_attribute((
+                    "count",
+                    Conditional::new(ElementAccess::new(Identifier::new("var"), "enabled"), 1, 0),
+                ))
                 .add_attribute(("bucket", "mybucket"))
                 .add_attribute(("force_destroy", true))
                 .add_block(

--- a/src/structure/conditional.rs
+++ b/src/structure/conditional.rs
@@ -1,0 +1,32 @@
+use super::Expression;
+use serde::{Deserialize, Serialize};
+
+/// The conditional operator allows selecting from one of two expressions based on the outcome of a
+/// boolean expression.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[serde(rename = "$hcl::conditional")]
+pub struct Conditional {
+    /// A predicate expression that evaluates to a boolean value.
+    pub predicate: Expression,
+    /// The expression returned by the conditional if the predicate evaluates to `true`.
+    pub true_expr: Expression,
+    /// The expression returned by the conditional if the predicate evaluates to `false`.
+    pub false_expr: Expression,
+}
+
+impl Conditional {
+    /// Creates a new `Conditional` from a predicate and two expressions for the branches of the
+    /// conditional.
+    pub fn new<P, T, F>(predicate: P, true_expr: T, false_expr: F) -> Conditional
+    where
+        P: Into<Expression>,
+        T: Into<Expression>,
+        F: Into<Expression>,
+    {
+        Conditional {
+            predicate: predicate.into(),
+            true_expr: true_expr.into(),
+            false_expr: false_expr.into(),
+        }
+    }
+}

--- a/src/structure/expression.rs
+++ b/src/structure/expression.rs
@@ -1,7 +1,7 @@
 //! Types to represent HCL attribute value expressions.
 
 use super::{ElementAccess, ElementAccessOperator, FuncCall, Identifier, TemplateExpr};
-use crate::{Number, Value};
+use crate::{Conditional, Number, Value};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{self, Display, Write};
@@ -38,6 +38,9 @@ pub enum Expression {
     FuncCall(Box<FuncCall>),
     /// Represents a sub-expression that is wrapped in parenthesis.
     SubExpr(Box<Expression>),
+    /// A conditional operator which selects one of two rexpressions based on the outcome of a
+    /// boolean expression.
+    Conditional(Box<Conditional>),
     /// Represents a raw HCL expression. This includes any expression kind that does match any of
     /// the enum variants above. See [`RawExpression`] for more details.
     Raw(RawExpression),
@@ -201,6 +204,12 @@ impl From<ElementAccess> for Expression {
 impl From<FuncCall> for Expression {
     fn from(func_call: FuncCall) -> Self {
         Expression::FuncCall(Box::new(func_call))
+    }
+}
+
+impl From<Conditional> for Expression {
+    fn from(cond: Conditional) -> Self {
+        Expression::Conditional(Box::new(cond))
     }
 }
 

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -48,6 +48,7 @@
 mod attribute;
 mod block;
 mod body;
+mod conditional;
 pub(crate) mod de;
 mod element_access;
 mod expression;
@@ -61,6 +62,7 @@ pub use self::{
     attribute::Attribute,
     block::{Block, BlockBuilder, BlockLabel},
     body::{Body, BodyBuilder},
+    conditional::Conditional,
     element_access::{ElementAccess, ElementAccessOperator},
     expression::{Expression, Object, ObjectKey, RawExpression},
     func::{FuncCall, FuncCallBuilder},

--- a/src/structure/ser/conditional.rs
+++ b/src/structure/ser/conditional.rs
@@ -1,0 +1,143 @@
+use super::expression::ExpressionSerializer;
+use crate::{serialize_unsupported, Conditional, Error, Expression, Result};
+use serde::ser::{self, Impossible};
+
+pub struct ConditionalSerializer;
+
+impl ser::Serializer for ConditionalSerializer {
+    type Ok = Conditional;
+    type Error = Error;
+
+    type SerializeSeq = SerializeConditionalSeq;
+    type SerializeTuple = SerializeConditionalSeq;
+    type SerializeTupleStruct = SerializeConditionalSeq;
+    type SerializeTupleVariant = Impossible<Conditional, Error>;
+    type SerializeMap = Impossible<Conditional, Error>;
+    type SerializeStruct = SerializeConditionalStruct;
+    type SerializeStructVariant = Impossible<Conditional, Error>;
+
+    serialize_unsupported! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64
+        char str bytes none unit unit_struct unit_variant
+        newtype_variant tuple_variant map struct_variant
+    }
+    serialize_self! { some newtype_struct }
+    forward_to_serialize_seq! { tuple tuple_struct }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(SerializeConditionalSeq::new())
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(SerializeConditionalStruct::new())
+    }
+}
+
+pub struct SerializeConditionalSeq {
+    predicate: Option<Expression>,
+    true_expr: Option<Expression>,
+    false_expr: Option<Expression>,
+}
+
+impl SerializeConditionalSeq {
+    pub fn new() -> Self {
+        SerializeConditionalSeq {
+            predicate: None,
+            true_expr: None,
+            false_expr: None,
+        }
+    }
+}
+
+impl ser::SerializeSeq for SerializeConditionalSeq {
+    type Ok = Conditional;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        if self.predicate.is_none() {
+            self.predicate = Some(value.serialize(ExpressionSerializer)?);
+        } else if self.true_expr.is_none() {
+            self.true_expr = Some(value.serialize(ExpressionSerializer)?);
+        } else if self.false_expr.is_none() {
+            self.false_expr = Some(value.serialize(ExpressionSerializer)?);
+        } else {
+            return Err(ser::Error::custom("expected sequence with 3 elements"));
+        }
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        match (self.predicate, self.true_expr, self.false_expr) {
+            (Some(predicate), Some(true_expr), Some(false_expr)) => Ok(Conditional {
+                predicate,
+                true_expr,
+                false_expr,
+            }),
+            (_, _, _) => Err(ser::Error::custom("expected sequence with 3 elements")),
+        }
+    }
+}
+
+impl ser::SerializeTuple for SerializeConditionalSeq {
+    impl_forward_to_serialize_seq!(serialize_element, Conditional);
+}
+
+impl ser::SerializeTupleStruct for SerializeConditionalSeq {
+    impl_forward_to_serialize_seq!(serialize_field, Conditional);
+}
+
+pub struct SerializeConditionalStruct {
+    predicate: Option<Expression>,
+    true_expr: Option<Expression>,
+    false_expr: Option<Expression>,
+}
+
+impl SerializeConditionalStruct {
+    pub fn new() -> Self {
+        SerializeConditionalStruct {
+            predicate: None,
+            true_expr: None,
+            false_expr: None,
+        }
+    }
+}
+
+impl ser::SerializeStruct for SerializeConditionalStruct {
+    type Ok = Conditional;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        match key {
+            "predicate" => self.predicate = Some(value.serialize(ExpressionSerializer)?),
+            "true_expr" => self.true_expr = Some(value.serialize(ExpressionSerializer)?),
+            "false_expr" => self.false_expr = Some(value.serialize(ExpressionSerializer)?),
+            _ => {
+                return Err(ser::Error::custom(
+                    "expected struct with fields `predicate`, `true_expr` and `false_expr`",
+                ))
+            }
+        };
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        match (self.predicate, self.true_expr, self.false_expr) {
+            (Some(predicate), Some(true_expr), Some(false_expr)) => Ok(Conditional {
+                predicate,
+                true_expr,
+                false_expr,
+            }),
+            (_, _, _) => Err(ser::Error::custom(
+                "expected struct with fields `predicate`, `true_expr` and `false_expr`",
+            )),
+        }
+    }
+}

--- a/src/structure/ser/mod.rs
+++ b/src/structure/ser/mod.rs
@@ -3,6 +3,7 @@
 mod attribute;
 mod block;
 pub(crate) mod body;
+mod conditional;
 mod element_access;
 mod expression;
 mod func;

--- a/src/structure/ser/tests.rs
+++ b/src/structure/ser/tests.rs
@@ -2,12 +2,13 @@ use super::{
     attribute::AttributeSerializer,
     block::{BlockLabelSerializer, BlockSerializer},
     body::BodySerializer,
+    conditional::ConditionalSerializer,
     expression::ExpressionSerializer,
     template::TemplateExprSerializer,
     *,
 };
 use crate::{
-    structure::Identifier, Attribute, Block, BlockLabel, Body, Expression, Heredoc,
+    structure::Identifier, Attribute, Block, BlockLabel, Body, Conditional, Expression, Heredoc,
     HeredocStripMode, Map, TemplateExpr,
 };
 use serde::Serialize;
@@ -75,6 +76,10 @@ fn identity() {
     test_identity(
         TemplateExprSerializer,
         TemplateExpr::Heredoc(Heredoc::new(Identifier::new("EOS"), "${foo}")),
+    );
+    test_identity(
+        ConditionalSerializer,
+        Conditional::new(Identifier::new("some_cond_var"), "yes", "no"),
     );
 }
 
@@ -166,5 +171,15 @@ fn custom() {
         ExpressionSerializer,
         Some(1u8),
         Expression::Number(1u8.into()),
+    );
+
+    test_serialize(
+        ConditionalSerializer,
+        (
+            Expression::VariableExpr(Identifier::new("some_cond_var")),
+            Expression::String("yes".into()),
+            Expression::String("no".into()),
+        ),
+        Conditional::new(Identifier::new("some_cond_var"), "yes", "no"),
     );
 }


### PR DESCRIPTION
This adds supports for parsing and serializing conditionals (e.g. `attr = var.some_cond ? true_expr : false_expr`).