### PR TITLE
feat: add `Expression::ForExpr`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,9 +16,8 @@
 /// - Attribute expression values can be any valid primitive, collection, expression or raw HCL
 ///   expression (`#{raw_expr}`).
 ///
-/// Please note that HCL actually uses `${}` for interpolating raw expressions, but since rust
-/// macros do not support matching on `$` it was chosen to use `#{}` instead to support raw
-/// expressions.
+/// Please note that HCL actually uses `${}` for interpolating expression, but since rust macros do
+/// not support matching on `$` it was chosen to use `#{}` instead to support raw expressions.
 ///
 /// ## Unsupported syntax:
 ///

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -98,9 +98,10 @@ Variadic  =  { "..." }
 // For expressions
 ForExpr       = { ForTupleExpr | ForObjectExpr }
 ForTupleExpr  = { "[" ~ ForIntro ~ Expression ~ ForCond? ~ "]" }
-ForObjectExpr = { "{" ~ ForIntro ~ Expression ~ "=>" ~ Expression ~ "..."? ~ ForCond? ~ "}" }
+ForObjectExpr = { "{" ~ ForIntro ~ Expression ~ "=>" ~ Expression ~ ValueGrouping? ~ ForCond? ~ "}" }
 ForIntro      = { "for" ~ Identifier ~ ("," ~ Identifier)? ~ "in" ~ Expression ~ ":" }
 ForCond       = { "if" ~ Expression }
+ValueGrouping = { "..." }
 
 // Variables and variable expressions
 VariableExpr = @{ Identifier }

--- a/src/parser/template.rs
+++ b/src/parser/template.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::template::*;
+use crate::template::{ForExpr, *};
 
 pub fn parse(input: &str) -> Result<Template> {
     let pair = HclParser::parse(Rule::HclTemplate, input)?.next().unwrap();

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -263,14 +263,6 @@ fn serialize_for_expr() {
                 .with_cond(Identifier::new("item")),
             ),
         ))
-        .build();
-
-    assert_eq!(
-        to_string(&body).unwrap(),
-        "list = [for item in items : func(item) if item]\n"
-    );
-
-    let body = Body::builder()
         .add_attribute((
             "object",
             ForExpr::Object(
@@ -287,15 +279,23 @@ fn serialize_for_expr() {
                         .arg(Identifier::new("value"))
                         .build(),
                 )
+                .with_cond(Operation::Binary(BinaryOp::new(
+                    Identifier::new("value"),
+                    BinaryOperator::NotEq,
+                    Expression::Null,
+                )))
                 .with_value_grouping(true),
             ),
         ))
         .build();
 
-    assert_eq!(
-        to_string(&body).unwrap(),
-        "object = {for key, value in items : toupper(key) => tolower(value)...}\n"
-    );
+    let expected = r#"
+list = [for item in items : func(item) if item]
+object = {for key, value in items : toupper(key) => tolower(value)... if value != null}
+"#
+    .trim_start();
+
+    assert_eq!(to_string(&body).unwrap(), expected);
 }
 
 #[test]

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::{
     BinaryOp, BinaryOperator, Block, BlockLabel, Body, Conditional, ElementAccess,
-    ElementAccessOperator, Expression, FuncCall, Heredoc, HeredocStripMode, Identifier, Object,
-    ObjectKey, Operation, RawExpression, TemplateExpr,
+    ElementAccessOperator, Expression, ForExpr, ForIntro, ForListExpr, ForObjectExpr, FuncCall,
+    Heredoc, HeredocStripMode, Identifier, Object, ObjectKey, Operation, RawExpression,
+    TemplateExpr,
 };
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -233,7 +234,7 @@ fn serialize_conditional() {
 }
 
 #[test]
-fn serialize_oparation() {
+fn serialize_operation() {
     let body = Body::builder()
         .add_attribute((
             "op",
@@ -242,6 +243,59 @@ fn serialize_oparation() {
         .build();
 
     assert_eq!(to_string(&body).unwrap(), "op = 1 + 1\n");
+}
+
+#[test]
+fn serialize_for_expr() {
+    let body = Body::builder()
+        .add_attribute((
+            "list",
+            ForExpr::List(
+                ForListExpr::new(
+                    ForIntro::new(
+                        Identifier::new("item"),
+                        Expression::VariableExpr(Identifier::new("items")),
+                    ),
+                    FuncCall::builder("func")
+                        .arg(Identifier::new("item"))
+                        .build(),
+                )
+                .with_cond(Identifier::new("item")),
+            ),
+        ))
+        .build();
+
+    assert_eq!(
+        to_string(&body).unwrap(),
+        "list = [for item in items : func(item) if item]\n"
+    );
+
+    let body = Body::builder()
+        .add_attribute((
+            "object",
+            ForExpr::Object(
+                ForObjectExpr::new(
+                    ForIntro::new(
+                        Identifier::new("value"),
+                        Expression::VariableExpr(Identifier::new("items")),
+                    )
+                    .with_key(Identifier::new("key")),
+                    FuncCall::builder("toupper")
+                        .arg(Identifier::new("key"))
+                        .build(),
+                    FuncCall::builder("tolower")
+                        .arg(Identifier::new("value"))
+                        .build(),
+                )
+                .with_value_grouping(true),
+            ),
+        ))
+        .build();
+
+    assert_eq!(
+        to_string(&body).unwrap(),
+        "object = {for key, value in items : toupper(key) => tolower(value)...}\n"
+    );
 }
 
 #[test]

--- a/src/structure/expression.rs
+++ b/src/structure/expression.rs
@@ -43,6 +43,8 @@ pub enum Expression {
     Conditional(Box<Conditional>),
     /// An operation which applies a particular operator to either one or two expression terms.
     Operation(Box<Operation>),
+    /// A construct for constructing a collection by projecting the items from another collection.
+    ForExpr(Box<ForExpr>),
     /// Represents a raw HCL expression. See [`RawExpression`] for more details.
     Raw(RawExpression),
 }
@@ -217,6 +219,12 @@ impl From<Conditional> for Expression {
 impl From<Operation> for Expression {
     fn from(op: Operation) -> Self {
         Expression::Operation(Box::new(op))
+    }
+}
+
+impl From<ForExpr> for Expression {
+    fn from(expr: ForExpr) -> Self {
+        Expression::ForExpr(Box::new(expr))
     }
 }
 

--- a/src/structure/expression.rs
+++ b/src/structure/expression.rs
@@ -45,7 +45,8 @@ pub enum Expression {
     Operation(Box<Operation>),
     /// A construct for constructing a collection by projecting the items from another collection.
     ForExpr(Box<ForExpr>),
-    /// Represents a raw HCL expression. See [`RawExpression`] for more details.
+    /// Represents a raw HCL expression. This variant will never be emitted by the parser. See
+    /// [`RawExpression`] for more details.
     Raw(RawExpression),
 }
 
@@ -258,8 +259,7 @@ pub enum ObjectKey {
     Identifier(Identifier),
     /// Represents a quoted string used as object key.
     String(String),
-    /// Represents a raw HCL expression. This includes any expression kind that does match any of
-    /// the enum variants above. See [`RawExpression`] for more details.
+    /// Represents a raw HCL expression. See [`RawExpression`] for more details.
     RawExpression(RawExpression),
 }
 
@@ -328,8 +328,6 @@ impl Display for ObjectKey {
 ///
 /// *Please note*: raw expressions are not validated during serialization, so it is your
 /// responsiblity to ensure that they are valid HCL.
-///
-/// As of now, only `for` expressions are treated as raw expression and are not further parsed.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename = "$hcl::raw_expression")]
 pub struct RawExpression(String);

--- a/src/structure/for_expr.rs
+++ b/src/structure/for_expr.rs
@@ -1,0 +1,155 @@
+use super::{Expression, Identifier};
+use serde::{Deserialize, Serialize};
+
+/// A for expression is a construct for constructing a collection by projecting the items from
+/// another collection.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[serde(rename = "$hcl::for_expr")]
+pub enum ForExpr {
+    /// Represents a `for` expression that produces a list.
+    List(ForListExpr),
+    /// Represents a `for` expression that produces an object.
+    Object(ForObjectExpr),
+}
+
+impl From<ForListExpr> for ForExpr {
+    fn from(expr: ForListExpr) -> Self {
+        ForExpr::List(expr)
+    }
+}
+
+impl From<ForObjectExpr> for ForExpr {
+    fn from(expr: ForObjectExpr) -> Self {
+        ForExpr::Object(expr)
+    }
+}
+
+/// A `for` expression that produces a list.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[serde(rename = "$hcl::for_list_expr")]
+pub struct ForListExpr {
+    /// The "introduction" of the `for` expression.
+    pub intro: ForIntro,
+    /// An expression that is evaluated once for each element in the source collection.
+    pub expr: Expression,
+    /// An optional filter predicate. Elements for which the predicate evaluates to `true` will be
+    /// evaluated as normal, while if `false` the element will be skipped.
+    pub cond: Option<Expression>,
+}
+
+impl ForListExpr {
+    /// Create a new `ForListExpr` with given intro and an expression that is evaluated once for
+    /// each element in the source collection.
+    pub fn new<T>(intro: ForIntro, expr: T) -> ForListExpr
+    where
+        T: Into<Expression>,
+    {
+        ForListExpr {
+            intro,
+            expr: expr.into(),
+            cond: None,
+        }
+    }
+
+    /// Sets filter predicate. Elements for which the predicate evaluates to `true` will be
+    /// evaluated as normal, while if `false` the element will be skipped.
+    pub fn with_cond<T>(mut self, expr: T) -> ForListExpr
+    where
+        T: Into<Expression>,
+    {
+        self.cond = Some(expr.into());
+        self
+    }
+}
+
+/// A `for` expression that produces an object.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[serde(rename = "$hcl::for_object_expr")]
+pub struct ForObjectExpr {
+    /// The "introduction" of the `for` expression.
+    pub intro: ForIntro,
+    /// An expression that is evaluated once for each element key in the source collection.
+    pub key_expr: Expression,
+    /// An expression that is evaluated once for each element value in the source collection.
+    pub value_expr: Expression,
+    /// Indicates whether value grouping mode is enabled. In grouping mode, each value in the
+    /// resulting object is a list of all of the values that were produced against each distinct
+    /// key.
+    pub value_grouping: bool,
+    /// An optional filter predicate. Elements for which the predicate evaluates to `true` will be
+    /// evaluated as normal, while if `false` the element will be skipped.
+    pub cond: Option<Expression>,
+}
+
+impl ForObjectExpr {
+    /// Create a new `ForObjectExpr` with given intro and an two expressions that is evaluated
+    /// once for each element's key and value in the source collection.
+    pub fn new<K, V>(intro: ForIntro, key_expr: K, value_expr: V) -> ForObjectExpr
+    where
+        K: Into<Expression>,
+        V: Into<Expression>,
+    {
+        ForObjectExpr {
+            intro,
+            key_expr: key_expr.into(),
+            value_expr: value_expr.into(),
+            value_grouping: false,
+            cond: None,
+        }
+    }
+
+    /// Sets filter predicate. Elements for which the predicate evaluates to `true` will be
+    /// evaluated as normal, while if `false` the element will be skipped.
+    pub fn with_cond<T>(mut self, expr: T) -> ForObjectExpr
+    where
+        T: Into<Expression>,
+    {
+        self.cond = Some(expr.into());
+        self
+    }
+
+    /// Enables or disabled value grouping mode.
+    pub fn with_value_grouping(mut self, yes: bool) -> ForObjectExpr {
+        self.value_grouping = yes;
+        self
+    }
+}
+
+/// The `for` keyword followed by either one or two identifiers, the `in` keyword and an
+/// expression that must evaluate to a value that can be iterated.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[serde(rename = "$hcl::for_intro")]
+pub struct ForIntro {
+    /// Optional name of the variable that will be temporarily assigned the key of each element
+    /// during iteration. For lists, this represents the zero-based element index, for objects this
+    /// represents the object key.
+    pub key: Option<Identifier>,
+    /// The name of the variable that will be temporarily assigned the value of each element during
+    /// iteration.
+    pub value: Identifier,
+    /// An expression that must evaluate to a value that can be iterated.
+    pub expr: Expression,
+}
+
+impl ForIntro {
+    /// Creates a new `ForIntro` with the name of the variable that will be temporarily assigned
+    /// the value of each element during iteration and an expression that must evaluate to a value
+    /// that can be iterated.
+    pub fn new<T>(value: Identifier, expr: T) -> ForIntro
+    where
+        T: Into<Expression>,
+    {
+        ForIntro {
+            key: None,
+            value,
+            expr: expr.into(),
+        }
+    }
+
+    /// Adds the iterator key variable identifier to the `for` expression and returns the modified
+    /// `ForIntro`.
+    pub fn with_key(mut self, key: Identifier) -> ForIntro {
+        self.key = Some(key);
+        self
+    }
+}

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -52,6 +52,7 @@ mod conditional;
 pub(crate) mod de;
 mod element_access;
 mod expression;
+mod for_expr;
 mod func;
 mod operation;
 pub(crate) mod ser;
@@ -66,6 +67,7 @@ pub use self::{
     conditional::Conditional,
     element_access::{ElementAccess, ElementAccessOperator},
     expression::{Expression, Object, ObjectKey, RawExpression},
+    for_expr::{ForExpr, ForIntro, ForListExpr, ForObjectExpr},
     func::{FuncCall, FuncCallBuilder},
     operation::{BinaryOp, BinaryOperator, Operation, UnaryOp, UnaryOperator},
     template::{Heredoc, HeredocStripMode, TemplateExpr},

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -7,6 +7,7 @@
 //! - [`BlockBuilder`]: provides functionality for building `Block`s
 //! - [`Body`]: represent the body of an HCL configuration or block
 //! - [`BodyBuilder`]: provides functionality for building `Body`s
+//! - [`Expression`]: represent the value of an HCL attribute
 //!
 //! ## Examples
 //!

--- a/src/structure/ser/expression.rs
+++ b/src/structure/ser/expression.rs
@@ -1,6 +1,6 @@
 use super::{
     conditional::ConditionalSerializer, element_access::SerializeElementAccessStruct,
-    func::SerializeFuncCallStruct, operation::OperationSerializer,
+    for_expr::ForExprSerializer, func::SerializeFuncCallStruct, operation::OperationSerializer,
     template::TemplateExprSerializer, StringSerializer,
 };
 use crate::{Error, Expression, Identifier, Object, ObjectKey, RawExpression, Result};
@@ -136,6 +136,9 @@ impl ser::Serializer for ExpressionSerializer {
                 ))),
                 "Operation" => Ok(Expression::Operation(Box::new(
                     value.serialize(OperationSerializer)?,
+                ))),
+                "ForExpr" => Ok(Expression::ForExpr(Box::new(
+                    value.serialize(ForExprSerializer)?,
                 ))),
                 "SubExpr" => Ok(Expression::SubExpr(Box::new(value.serialize(self)?))),
                 "TemplateExpr" => Ok(Expression::TemplateExpr(Box::new(

--- a/src/structure/ser/for_expr.rs
+++ b/src/structure/ser/for_expr.rs
@@ -1,5 +1,5 @@
-use super::{expression::ExpressionSerializer, BoolSerializer, StringSerializer, OptionSerializer};
-use crate::{Error, Expression, ForExpr, ForIntro, ForListExpr, ForObjectExpr, Result, Identifier};
+use super::{expression::ExpressionSerializer, BoolSerializer, OptionSerializer, StringSerializer};
+use crate::{Error, Expression, ForExpr, ForIntro, ForListExpr, ForObjectExpr, Identifier, Result};
 use serde::ser::{self, Impossible, Serialize};
 
 pub struct ForExprSerializer;
@@ -139,7 +139,9 @@ impl ser::SerializeStruct for SerializeForListExprStruct {
         match key {
             "intro" => self.intro = Some(value.serialize(ForIntroSerializer)?),
             "expr" => self.expr = Some(value.serialize(ExpressionSerializer)?),
-            "cond" => self.cond = Some(value.serialize(OptionSerializer::new(ExpressionSerializer))?),
+            "cond" => {
+                self.cond = Some(value.serialize(OptionSerializer::new(ExpressionSerializer))?)
+            }
             _ => {
                 return Err(ser::Error::custom(
                     "expected struct with fields `intro`, `expr` and `cond`",
@@ -233,12 +235,12 @@ impl ser::SerializeStruct for SerializeForObjectExprStruct {
     fn end(self) -> Result<Self::Ok> {
         match (self.intro, self.key_expr, self.value_expr, self.value_grouping, self.cond) {
             (Some(intro), Some(key_expr), Some(value_expr), Some(value_grouping), Some(cond)) => {
-                Ok(ForObjectExpr { 
-                    intro, 
-                    key_expr, 
-                    value_expr, 
-                    value_grouping, 
-                    cond 
+                Ok(ForObjectExpr {
+                    intro,
+                    key_expr,
+                    value_expr,
+                    value_grouping,
+                    cond,
                 })
             },
             (_, _, _, _, _) => Err(ser::Error::custom(
@@ -302,7 +304,7 @@ impl ser::SerializeStruct for SerializeForIntroStruct {
             "key" => {
                 let key = value.serialize(OptionSerializer::new(StringSerializer))?;
                 self.key = Some(key.map(Identifier::from))
-            },
+            }
             "value" => self.value = Some(Identifier::from(value.serialize(StringSerializer)?)),
             "expr" => self.expr = Some(value.serialize(ExpressionSerializer)?),
             _ => {

--- a/src/structure/ser/for_expr.rs
+++ b/src/structure/ser/for_expr.rs
@@ -1,0 +1,326 @@
+use super::{expression::ExpressionSerializer, BoolSerializer, StringSerializer, OptionSerializer};
+use crate::{Error, Expression, ForExpr, ForIntro, ForListExpr, ForObjectExpr, Result, Identifier};
+use serde::ser::{self, Impossible, Serialize};
+
+pub struct ForExprSerializer;
+
+impl ser::Serializer for ForExprSerializer {
+    type Ok = ForExpr;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<ForExpr, Error>;
+    type SerializeTuple = Impossible<ForExpr, Error>;
+    type SerializeTupleStruct = Impossible<ForExpr, Error>;
+    type SerializeTupleVariant = Impossible<ForExpr, Error>;
+    type SerializeMap = Impossible<ForExpr, Error>;
+    type SerializeStruct = SerializeForExprStruct;
+    type SerializeStructVariant = Impossible<ForExpr, Error>;
+
+    serialize_unsupported! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64
+        char str bytes none unit unit_struct unit_variant
+        seq tuple tuple_struct tuple_variant map struct_variant
+    }
+    serialize_self! { some newtype_struct }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        // Specialization for the `ForExpr` type itself.
+        match (name, variant) {
+            ("$hcl::for_expr", "Object") => {
+                Ok(ForExpr::Object(value.serialize(ForObjectExprSerializer)?))
+            }
+            (_, _) => Ok(ForExpr::List(value.serialize(ForListExprSerializer)?)),
+        }
+    }
+
+    fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(SerializeForExprStruct::new(name))
+    }
+}
+
+pub enum SerializeForExprStruct {
+    List(SerializeForListExprStruct),
+    Object(SerializeForObjectExprStruct),
+}
+
+impl SerializeForExprStruct {
+    fn new(name: &'static str) -> Self {
+        // Specialization for the `ForListExpr` and `ForObjectExpr` types.
+        match name {
+            "$hcl::for_object_expr" => {
+                SerializeForExprStruct::Object(SerializeForObjectExprStruct::new())
+            }
+            _ => SerializeForExprStruct::List(SerializeForListExprStruct::new()),
+        }
+    }
+}
+
+impl ser::SerializeStruct for SerializeForExprStruct {
+    type Ok = ForExpr;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        match self {
+            SerializeForExprStruct::List(ser) => ser.serialize_field(key, value),
+            SerializeForExprStruct::Object(ser) => ser.serialize_field(key, value),
+        }
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        match self {
+            SerializeForExprStruct::List(ser) => ser.end().map(Into::into),
+            SerializeForExprStruct::Object(ser) => ser.end().map(Into::into),
+        }
+    }
+}
+
+pub struct ForListExprSerializer;
+
+impl ser::Serializer for ForListExprSerializer {
+    type Ok = ForListExpr;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<ForListExpr, Error>;
+    type SerializeTuple = Impossible<ForListExpr, Error>;
+    type SerializeTupleStruct = Impossible<ForListExpr, Error>;
+    type SerializeTupleVariant = Impossible<ForListExpr, Error>;
+    type SerializeMap = Impossible<ForListExpr, Error>;
+    type SerializeStruct = SerializeForListExprStruct;
+    type SerializeStructVariant = Impossible<ForListExpr, Error>;
+
+    serialize_unsupported! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str
+        bytes none unit unit_struct unit_variant newtype_variant
+        seq tuple tuple_struct tuple_variant map struct_variant
+    }
+    serialize_self! { some newtype_struct }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(SerializeForListExprStruct::new())
+    }
+}
+
+pub struct SerializeForListExprStruct {
+    intro: Option<ForIntro>,
+    expr: Option<Expression>,
+    cond: Option<Option<Expression>>,
+}
+
+impl SerializeForListExprStruct {
+    pub fn new() -> Self {
+        SerializeForListExprStruct {
+            intro: None,
+            expr: None,
+            cond: None,
+        }
+    }
+}
+
+impl ser::SerializeStruct for SerializeForListExprStruct {
+    type Ok = ForListExpr;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        match key {
+            "intro" => self.intro = Some(value.serialize(ForIntroSerializer)?),
+            "expr" => self.expr = Some(value.serialize(ExpressionSerializer)?),
+            "cond" => self.cond = Some(value.serialize(OptionSerializer::new(ExpressionSerializer))?),
+            _ => {
+                return Err(ser::Error::custom(
+                    "expected struct with fields `intro`, `expr` and `cond`",
+                ))
+            }
+        };
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        match (self.intro, self.expr, self.cond) {
+            (Some(intro), Some(expr), Some(cond)) => Ok(ForListExpr { intro, expr, cond }),
+            (_, _, _) => Err(ser::Error::custom(
+                "expected struct with fields `intro`, `expr` and `cond`",
+            )),
+        }
+    }
+}
+
+pub struct ForObjectExprSerializer;
+
+impl ser::Serializer for ForObjectExprSerializer {
+    type Ok = ForObjectExpr;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<ForObjectExpr, Error>;
+    type SerializeTuple = Impossible<ForObjectExpr, Error>;
+    type SerializeTupleStruct = Impossible<ForObjectExpr, Error>;
+    type SerializeTupleVariant = Impossible<ForObjectExpr, Error>;
+    type SerializeMap = Impossible<ForObjectExpr, Error>;
+    type SerializeStruct = SerializeForObjectExprStruct;
+    type SerializeStructVariant = Impossible<ForObjectExpr, Error>;
+
+    serialize_unsupported! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str
+        bytes none unit unit_struct unit_variant newtype_variant
+        seq tuple tuple_struct tuple_variant map struct_variant
+    }
+    serialize_self! { some newtype_struct }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(SerializeForObjectExprStruct::new())
+    }
+}
+
+pub struct SerializeForObjectExprStruct {
+    intro: Option<ForIntro>,
+    key_expr: Option<Expression>,
+    value_expr: Option<Expression>,
+    value_grouping: Option<bool>,
+    cond: Option<Option<Expression>>,
+}
+
+impl SerializeForObjectExprStruct {
+    pub fn new() -> Self {
+        SerializeForObjectExprStruct {
+            intro: None,
+            key_expr: None,
+            value_expr: None,
+            value_grouping: None,
+            cond: None,
+        }
+    }
+}
+
+impl ser::SerializeStruct for SerializeForObjectExprStruct {
+    type Ok = ForObjectExpr;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        match key {
+            "intro" => self.intro = Some(value.serialize(ForIntroSerializer)?),
+            "key_expr" => self.key_expr = Some(value.serialize(ExpressionSerializer)?),
+            "value_expr" => self.value_expr = Some(value.serialize(ExpressionSerializer)?),
+            "value_grouping" => self.value_grouping = Some(value.serialize(BoolSerializer)?),
+            "cond" => self.cond = Some(value.serialize(OptionSerializer::new(ExpressionSerializer))?),
+            _ => {
+                return Err(ser::Error::custom(
+                    "expected struct with fields `intro`, `key_expr`, `value_expr`, `value_grouping` and `cond`",
+                ))
+            }
+        };
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        match (self.intro, self.key_expr, self.value_expr, self.value_grouping, self.cond) {
+            (Some(intro), Some(key_expr), Some(value_expr), Some(value_grouping), Some(cond)) => {
+                Ok(ForObjectExpr { 
+                    intro, 
+                    key_expr, 
+                    value_expr, 
+                    value_grouping, 
+                    cond 
+                })
+            },
+            (_, _, _, _, _) => Err(ser::Error::custom(
+                "expected struct with fields `intro`, `key_expr`, `value_expr`, `value_grouping` and `cond`",
+            )),
+        }
+    }
+}
+
+pub struct ForIntroSerializer;
+
+impl ser::Serializer for ForIntroSerializer {
+    type Ok = ForIntro;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<ForIntro, Error>;
+    type SerializeTuple = Impossible<ForIntro, Error>;
+    type SerializeTupleStruct = Impossible<ForIntro, Error>;
+    type SerializeTupleVariant = Impossible<ForIntro, Error>;
+    type SerializeMap = Impossible<ForIntro, Error>;
+    type SerializeStruct = SerializeForIntroStruct;
+    type SerializeStructVariant = Impossible<ForIntro, Error>;
+
+    serialize_unsupported! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str
+        bytes none unit unit_struct unit_variant newtype_variant
+        seq tuple tuple_struct tuple_variant map struct_variant
+    }
+    serialize_self! { some newtype_struct }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(SerializeForIntroStruct::new())
+    }
+}
+
+pub struct SerializeForIntroStruct {
+    key: Option<Option<Identifier>>,
+    value: Option<Identifier>,
+    expr: Option<Expression>,
+}
+
+impl SerializeForIntroStruct {
+    pub fn new() -> Self {
+        SerializeForIntroStruct {
+            key: None,
+            value: None,
+            expr: None,
+        }
+    }
+}
+
+impl ser::SerializeStruct for SerializeForIntroStruct {
+    type Ok = ForIntro;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        match key {
+            "key" => {
+                let key = value.serialize(OptionSerializer::new(StringSerializer))?;
+                self.key = Some(key.map(Identifier::from))
+            },
+            "value" => self.value = Some(Identifier::from(value.serialize(StringSerializer)?)),
+            "expr" => self.expr = Some(value.serialize(ExpressionSerializer)?),
+            _ => {
+                return Err(ser::Error::custom(
+                    "expected struct with fields `key`, `value` and `expr`",
+                ))
+            }
+        };
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        match (self.key, self.value, self.expr) {
+            (Some(key), Some(value), Some(expr)) => Ok(ForIntro { key, value, expr }),
+            (_, _, _) => Err(ser::Error::custom(
+                "expected struct with fields `key`, `value` and `expr`",
+            )),
+        }
+    }
+}

--- a/src/structure/ser/tests.rs
+++ b/src/structure/ser/tests.rs
@@ -4,6 +4,7 @@ use super::{
     body::BodySerializer,
     conditional::ConditionalSerializer,
     expression::ExpressionSerializer,
+    for_expr::ForExprSerializer,
     operation::OperationSerializer,
     template::TemplateExprSerializer,
 };
@@ -85,6 +86,39 @@ fn identity() {
     test_identity(
         OperationSerializer,
         Operation::Binary(BinaryOp::new(1, BinaryOperator::Plus, 1)),
+    );
+    test_identity(
+        ForExprSerializer,
+        ForExpr::List(
+            ForListExpr::new(
+                ForIntro::new(
+                    Identifier::new("value"),
+                    vec![Expression::String(String::from("foo"))],
+                )
+                .with_key(Identifier::new("index")),
+                Identifier::new("other_value"),
+            )
+            .with_cond(Expression::Bool(true)),
+        ),
+    );
+    test_identity(
+        ForExprSerializer,
+        ForExpr::Object(
+            ForObjectExpr::new(
+                ForIntro::new(
+                    Identifier::new("value"),
+                    Expression::Object(Object::from_iter(vec![(
+                        ObjectKey::from("k"),
+                        Expression::String(String::from("v")),
+                    )])),
+                )
+                .with_key(Identifier::new("index")),
+                Identifier::new("other_key"),
+                Identifier::new("other_value"),
+            )
+            .with_cond(Expression::Bool(true))
+            .with_value_grouping(true),
+        ),
     );
 }
 


### PR DESCRIPTION
This adds supports for parsing and serializing `for` expressions, e.g. `attr = [for item in items : func(item)]` and `attr = {for key, value in objects : tolower(key) => value if value != null}`.