### PR TITLE
feat!: use `VecMap` for object expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ version = "1.7.0"
 features = ["derive"]
 version = "1.0.130"
 
+[dependencies.vecmap-rs]
+features = ["serde"]
+version = "0.1.1"
+
 [dev-dependencies]
 criterion = "0.3"
 assert-json-diff = "2.0.1"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -431,13 +431,11 @@ macro_rules! object_key {
 ///     (other)   = "world"
 /// });
 ///
-/// let expected = Expression::Object({
-///     let mut object = Object::new();
-///     object.insert(ObjectKey::identifier("foo"), true.into());
-///     object.insert(ObjectKey::string("baz qux"), vec![1u64, 2].into());
-///     object.insert(ObjectKey::string("hello"), "world".into());
-///     object
-/// });
+/// let expected = Expression::Object(Object::from([
+///     (ObjectKey::identifier("foo"), true.into()),
+///     (ObjectKey::string("baz qux"), vec![1u64, 2].into()),
+///     (ObjectKey::string("hello"), "world".into()),
+/// ]));
 ///
 /// assert_eq!(expression, expected);
 /// ```

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -91,15 +91,14 @@ fn serialize_body() {
                         .build(),
                 )
                 .add_attribute(("an_object", {
-                    let mut object = Object::new();
-
-                    object.insert(ObjectKey::identifier("foo"), "bar".into());
-                    object.insert(
-                        ObjectKey::string("enabled"),
-                        RawExpression::new("var.enabled").into(),
-                    );
-                    object.insert(ObjectKey::raw_expression("var.name"), "the value".into());
-                    object
+                    Object::from([
+                        (ObjectKey::identifier("foo"), "bar".into()),
+                        (
+                            ObjectKey::string("enabled"),
+                            RawExpression::new("var.enabled").into(),
+                        ),
+                        (ObjectKey::raw_expression("var.name"), "the value".into()),
+                    ])
                 }))
                 .build(),
         )

--- a/src/structure/expression.rs
+++ b/src/structure/expression.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use std::fmt::{self, Display, Write};
 
 /// The object type used in the expression sub-language.
-pub type Object<K, V> = indexmap::IndexMap<K, V>;
+pub type Object<K, V> = vecmap::VecMap<K, V>;
 
 /// A type representing the expression sub-language is used within attribute definitions to specify
 /// values.

--- a/src/structure/ser/expression.rs
+++ b/src/structure/ser/expression.rs
@@ -155,7 +155,7 @@ impl ser::Serializer for ExpressionSerializer {
             }
             ("$hcl::expression", _) => value.serialize(self),
             (_, _) => {
-                let mut object = Object::new();
+                let mut object = Object::with_capacity(1);
                 object.insert(ObjectKey::identifier(variant), value.serialize(self)?);
                 Ok(Expression::Object(object))
             }
@@ -270,7 +270,7 @@ impl ser::SerializeTupleVariant for SerializeExpressionTupleVariant {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        let mut object = Object::new();
+        let mut object = Object::with_capacity(1);
         object.insert(self.name, self.vec.into());
         Ok(Expression::Object(object))
     }
@@ -415,7 +415,7 @@ impl ser::SerializeStructVariant for SerializeExpressionStructVariant {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        let mut object = Object::new();
+        let mut object = Object::with_capacity(1);
         object.insert(self.name, self.map.into());
         Ok(Expression::Object(object))
     }

--- a/src/structure/ser/tests.rs
+++ b/src/structure/ser/tests.rs
@@ -109,7 +109,7 @@ fn identity() {
             ForObjectExpr::new(
                 ForIntro::new(
                     Identifier::new("value"),
-                    Expression::Object(Object::from_iter(vec![(
+                    Expression::Object(Object::from([(
                         ObjectKey::from("k"),
                         Expression::String(String::from("v")),
                     )])),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,13 +24,11 @@ fn expression_macro_arrays() {
 
 #[test]
 fn expression_macro_objects() {
-    let expected = Expression::Object({
-        let mut object = Object::new();
-        object.insert("foo".into(), "bar".into());
-        object.insert("baz".into(), true.into());
-        object.insert("qux".into(), vec![1, 2, 3].into());
-        object
-    });
+    let expected = Expression::Object(Object::from([
+        ("foo".into(), "bar".into()),
+        ("baz".into(), true.into()),
+        ("qux".into(), vec![1, 2, 3].into()),
+    ]));
 
     assert_eq!(
         expression!({
@@ -41,13 +39,11 @@ fn expression_macro_objects() {
         expected
     );
 
-    let expected = Expression::Object({
-        let mut object = Object::new();
-        object.insert(ObjectKey::identifier("foo"), "bar".into());
-        object.insert("bar".into(), true.into());
-        object.insert(ObjectKey::raw_expression("qux"), vec![1, 2, 3].into());
-        object
-    });
+    let expected = Expression::Object(Object::from([
+        (ObjectKey::identifier("foo"), "bar".into()),
+        ("bar".into(), true.into()),
+        (ObjectKey::raw_expression("qux"), vec![1, 2, 3].into()),
+    ]));
 
     let baz = "bar";
 


### PR DESCRIPTION
BREAKING CHANGE: The underlying map implementation for the `Object<K, V>` type changed from `IndexMap<K, V>` to `VecMap<K, V>`. For the most common operations this is a drop-in replacement, but `VecMap` lacks some of the more exotic APIs the `IndexMap` provides.

This change is necessary to add support for `Expression` as object key type since it is not `Hash` and not `Ord`.