### PR TITLE
fix!: prevent creation of infinite and NaN `Number`

### DIFF
--- a/src/format/impls.rs
+++ b/src/format/impls.rs
@@ -154,12 +154,7 @@ impl Format for Number {
     where
         W: io::Write,
     {
-        match *self {
-            Number::PosInt(pos) => fmt.write_int(pos)?,
-            Number::NegInt(neg) => fmt.write_int(neg)?,
-            Number::Float(float) => fmt.write_float(float)?,
-        }
-
+        fmt.write_string_fragment(&self.to_string())?;
         Ok(())
     }
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -236,16 +236,6 @@ where
         self.write_all(s.as_bytes())
     }
 
-    /// Writes a float value to the writer.
-    fn write_float<T>(&mut self, value: T) -> io::Result<()>
-    where
-        T: ryu::Float,
-    {
-        let mut buffer = ryu::Buffer::new();
-        let s = buffer.format_finite(value);
-        self.write_all(s.as_bytes())
-    }
-
     /// Writes a quoted string to the writer. The quoted string will be escaped.
     fn write_quoted_string(&mut self, s: &str) -> io::Result<()> {
         self.write_all(b"\"")?;

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,10 +1,17 @@
-use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt::{self, Display};
+use crate::Error;
+use serde::{de, forward_to_deserialize_any, ser};
+use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::ops::Neg;
 
 /// Represents a HCL number.
-#[derive(Debug, PartialEq, Clone)]
-pub enum Number {
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Number {
+    n: N,
+}
+
+#[derive(Clone, Copy)]
+enum N {
     /// Represents a positive integer.
     PosInt(u64),
     /// Represents a negative integer.
@@ -13,38 +20,88 @@ pub enum Number {
     Float(f64),
 }
 
-impl Eq for Number {}
+impl PartialEq for N {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (N::PosInt(a), N::PosInt(b)) => a == b,
+            (N::NegInt(a), N::NegInt(b)) => a == b,
+            (N::Float(a), N::Float(b)) => a == b,
+            (_, _) => false,
+        }
+    }
+}
+
+impl Eq for N {}
+
+impl Hash for N {
+    fn hash<H>(&self, h: &mut H)
+    where
+        H: Hasher,
+    {
+        match *self {
+            N::PosInt(i) => i.hash(h),
+            N::NegInt(i) => i.hash(h),
+            N::Float(f) => {
+                if f == 0.0f64 {
+                    // There are 2 zero representations, +0 and -0, which
+                    // compare equal but have different bits. We use the +0 hash
+                    // for both so that hash(+0) == hash(-0).
+                    0.0f64.to_bits().hash(h);
+                } else {
+                    f.to_bits().hash(h);
+                }
+            }
+        }
+    }
+}
 
 impl Number {
+    /// Creates a new `Number` from a `f64`. Returns `None` if the float is infinite or NaN.
+    ///
+    /// ```
+    /// use hcl::Number;
+    ///
+    /// assert!(Number::from_f64(42.0).is_some());
+    /// assert!(Number::from_f64(f64::NAN).is_none());
+    /// assert!(Number::from_f64(f64::INFINITY).is_none());
+    /// assert!(Number::from_f64(f64::NEG_INFINITY).is_none());
+    /// ```
+    pub fn from_f64(f: f64) -> Option<Number> {
+        if f.is_finite() {
+            Some(Number { n: N::Float(f) })
+        } else {
+            None
+        }
+    }
     /// Represents the `Number` as f64 if possible. Returns None otherwise.
     pub fn as_f64(&self) -> Option<f64> {
-        match *self {
-            Self::PosInt(n) => Some(n as f64),
-            Self::NegInt(n) => Some(n as f64),
-            Self::Float(n) => Some(n),
+        match self.n {
+            N::PosInt(n) => Some(n as f64),
+            N::NegInt(n) => Some(n as f64),
+            N::Float(n) => Some(n),
         }
     }
 
     /// If the `Number` is an integer, represent it as i64 if possible. Returns None otherwise.
     pub fn as_i64(&self) -> Option<i64> {
-        match *self {
-            Self::PosInt(n) => {
+        match self.n {
+            N::PosInt(n) => {
                 if n <= i64::max_value() as u64 {
                     Some(n as i64)
                 } else {
                     None
                 }
             }
-            Self::NegInt(n) => Some(n),
-            Self::Float(_) => None,
+            N::NegInt(n) => Some(n),
+            N::Float(_) => None,
         }
     }
 
     /// If the `Number` is an integer, represent it as u64 if possible. Returns None otherwise.
     pub fn as_u64(&self) -> Option<u64> {
-        match *self {
-            Self::PosInt(n) => Some(n),
-            Self::NegInt(_) | Self::Float(_) => None,
+        match self.n {
+            N::PosInt(n) => Some(n),
+            N::NegInt(_) | N::Float(_) => None,
         }
     }
 
@@ -53,9 +110,9 @@ impl Number {
     /// For any `Number` on which `is_f64` returns true, `as_f64` is guaranteed to return the
     /// float value.
     pub fn is_f64(&self) -> bool {
-        match self {
-            Self::Float(_) => true,
-            Self::PosInt(_) | Self::NegInt(_) => false,
+        match self.n {
+            N::Float(_) => true,
+            N::PosInt(_) | N::NegInt(_) => false,
         }
     }
 
@@ -64,10 +121,10 @@ impl Number {
     /// For any `Number` on which `is_i64` returns true, `as_i64` is guaranteed to return the
     /// integer value.
     pub fn is_i64(&self) -> bool {
-        match *self {
-            Self::PosInt(v) => v <= i64::max_value() as u64,
-            Self::NegInt(_) => true,
-            Self::Float(_) => false,
+        match self.n {
+            N::PosInt(v) => v <= i64::max_value() as u64,
+            N::NegInt(_) => true,
+            N::Float(_) => false,
         }
     }
 
@@ -76,9 +133,9 @@ impl Number {
     /// For any `Number` on which `is_u64` returns true, `as_u64` is guaranteed to return the
     /// integer value.
     pub fn is_u64(&self) -> bool {
-        match self {
-            Self::PosInt(_) => true,
-            Self::NegInt(_) | Self::Float(_) => false,
+        match self.n {
+            N::PosInt(_) => true,
+            N::NegInt(_) | N::Float(_) => false,
         }
     }
 }
@@ -88,7 +145,9 @@ macro_rules! impl_from_unsigned {
         $(
             impl From<$ty> for Number {
                 fn from(u: $ty) -> Self {
-                    Self::PosInt(u as u64)
+                    Number {
+                        n: N::PosInt(u as u64)
+                    }
                 }
             }
         )*
@@ -100,11 +159,13 @@ macro_rules! impl_from_signed {
         $(
             impl From<$ty> for Number {
                 fn from(i: $ty) -> Self {
-                    if i < 0 {
-                        Self::NegInt(i as i64)
+                    let n = if i < 0 {
+                        N::NegInt(i as i64)
                     } else {
-                        Self::PosInt(i as u64)
-                    }
+                        N::PosInt(i as u64)
+                    };
+
+                    Number { n }
                 }
             }
         )*
@@ -114,53 +175,47 @@ macro_rules! impl_from_signed {
 impl_from_unsigned!(u8, u16, u32, u64, usize);
 impl_from_signed!(i8, i16, i32, i64, isize);
 
-impl From<f32> for Number {
-    fn from(f: f32) -> Self {
-        Self::Float(f as f64)
-    }
-}
-
-impl From<f64> for Number {
-    fn from(f: f64) -> Self {
-        Self::Float(f)
-    }
-}
-
-impl Display for Number {
+impl fmt::Display for Number {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::PosInt(i) => Display::fmt(&i, formatter),
-            Self::NegInt(i) => Display::fmt(&i, formatter),
-            Self::Float(f) => Display::fmt(&f, formatter),
+        match self.n {
+            N::PosInt(u) => formatter.write_str(itoa::Buffer::new().format(u)),
+            N::NegInt(i) => formatter.write_str(itoa::Buffer::new().format(i)),
+            N::Float(f) => formatter.write_str(ryu::Buffer::new().format_finite(f)),
         }
     }
 }
 
-impl Serialize for Number {
+impl fmt::Debug for Number {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "Number({})", self)
+    }
+}
+
+impl ser::Serialize for Number {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
-        match *self {
-            Self::PosInt(i) => serializer.serialize_u64(i),
-            Self::NegInt(i) => serializer.serialize_i64(i),
-            Self::Float(f) => serializer.serialize_f64(f),
+        match self.n {
+            N::PosInt(i) => serializer.serialize_u64(i),
+            N::NegInt(i) => serializer.serialize_i64(i),
+            N::Float(f) => serializer.serialize_f64(f),
         }
     }
 }
 
-impl<'de> Deserialize<'de> for Number {
+impl<'de> de::Deserialize<'de> for Number {
     fn deserialize<D>(deserializer: D) -> Result<Number, D::Error>
     where
-        D: Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         struct NumberVisitor;
 
-        impl<'de> Visitor<'de> for NumberVisitor {
+        impl<'de> de::Visitor<'de> for NumberVisitor {
             type Value = Number;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a HCL number")
+                formatter.write_str("an HCL number")
             }
 
             fn visit_i64<E>(self, value: i64) -> Result<Number, E> {
@@ -171,8 +226,11 @@ impl<'de> Deserialize<'de> for Number {
                 Ok(value.into())
             }
 
-            fn visit_f64<E>(self, value: f64) -> Result<Number, E> {
-                Ok(value.into())
+            fn visit_f64<E>(self, value: f64) -> Result<Number, E>
+            where
+                E: de::Error,
+            {
+                Number::from_f64(value).ok_or_else(|| de::Error::custom("not an HCL number"))
             }
         }
 
@@ -180,21 +238,44 @@ impl<'de> Deserialize<'de> for Number {
     }
 }
 
+impl<'de> de::Deserializer<'de> for Number {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.n {
+            N::PosInt(i) => visitor.visit_u64(i),
+            N::NegInt(i) => visitor.visit_i64(i),
+            N::Float(f) => visitor.visit_f64(f),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct enum map struct identifier ignored_any
+    }
+}
+
 impl Neg for Number {
     type Output = Number;
 
     fn neg(self) -> Self::Output {
-        match self {
-            Number::PosInt(value) => Number::NegInt(-(value as i64)),
-            Number::NegInt(value) => {
+        let n = match self.n {
+            N::PosInt(value) => N::NegInt(-(value as i64)),
+            N::NegInt(value) => {
                 let value = -value;
                 if value < 0 {
-                    Number::NegInt(value)
+                    N::NegInt(value)
                 } else {
-                    Number::PosInt(value as u64)
+                    N::PosInt(value as u64)
                 }
             }
-            Number::Float(value) => Number::Float(-value),
-        }
+            N::Float(value) => N::Float(-value),
+        };
+
+        Number { n }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,7 +3,7 @@ mod template;
 mod tests;
 
 pub use self::template::parse as parse_template;
-use crate::{structure::*, util::unescape, Result};
+use crate::{structure::*, util::unescape, Number, Result};
 use pest::{
     iterators::{Pair, Pairs},
     Parser as ParserTrait,
@@ -178,7 +178,8 @@ fn parse_expr_term(pair: Pair<Rule>) -> Result<Expression> {
 
     let expr = match pair.as_rule() {
         Rule::BooleanLit => Expression::Bool(parse_primitive(pair)),
-        Rule::Float => Expression::Number(parse_primitive::<f64>(pair).into()),
+        Rule::Float => Number::from_f64(parse_primitive::<f64>(pair))
+            .map_or(Expression::Null, Expression::Number),
         Rule::Int => Expression::Number(parse_primitive::<i64>(pair).into()),
         Rule::NullLit => Expression::Null,
         Rule::StringLit => parse_string(inner(pair)).map(Expression::String)?,

--- a/src/structure/de.rs
+++ b/src/structure/de.rs
@@ -1,7 +1,7 @@
 //! Deserialize impls for HCL structure types.
 
 use super::*;
-use crate::{Error, Number, Result};
+use crate::{Error, Result};
 use serde::de::value::{MapAccessDeserializer, StrDeserializer};
 use serde::de::{self, IntoDeserializer};
 use serde::{forward_to_deserialize_any, Deserializer};
@@ -250,11 +250,7 @@ impl<'de> de::Deserializer<'de> for Expression {
         match self {
             Expression::Null => visitor.visit_unit(),
             Expression::Bool(b) => visitor.visit_bool(b),
-            Expression::Number(n) => match n {
-                Number::PosInt(i) => visitor.visit_u64(i),
-                Number::NegInt(i) => visitor.visit_i64(i),
-                Number::Float(f) => visitor.visit_f64(f),
-            },
+            Expression::Number(n) => n.deserialize_any(visitor),
             Expression::String(s) => visitor.visit_string(s),
             Expression::Array(array) => visitor.visit_seq(array.into_deserializer()),
             Expression::Object(object) => visitor.visit_map(object.into_deserializer()),

--- a/src/structure/expression.rs
+++ b/src/structure/expression.rs
@@ -113,13 +113,13 @@ impl_from_integer!(u8, u16, u32, u64, usize);
 
 impl From<f32> for Expression {
     fn from(f: f32) -> Self {
-        Expression::Number(f.into())
+        From::from(f as f64)
     }
 }
 
 impl From<f64> for Expression {
     fn from(f: f64) -> Self {
-        Expression::Number(f.into())
+        Number::from_f64(f).map_or(Expression::Null, Expression::Number)
     }
 }
 

--- a/src/structure/ser/expression.rs
+++ b/src/structure/ser/expression.rs
@@ -7,7 +7,7 @@ use super::{
     template::{SerializeTemplateExprStruct, TemplateExprSerializer},
     StringSerializer,
 };
-use crate::{Error, Expression, Identifier, Object, ObjectKey, RawExpression, Result};
+use crate::{Error, Expression, Identifier, Number, Object, ObjectKey, RawExpression, Result};
 use serde::ser::{self, Impossible, SerializeMap};
 use std::fmt::Display;
 
@@ -70,7 +70,7 @@ impl ser::Serializer for ExpressionSerializer {
     }
 
     fn serialize_f64(self, value: f64) -> Result<Self::Ok> {
-        Ok(Expression::Number(value.into()))
+        Ok(Number::from_f64(value).map_or(Expression::Null, Expression::Number))
     }
 
     fn serialize_char(self, value: char) -> Result<Self::Ok> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,7 @@ fn expression_macro_primitives() {
     assert_eq!(expression!(true), Expression::Bool(true));
     assert_eq!(expression!(false), Expression::Bool(false));
     assert_eq!(expression!(0), Expression::Number(Number::from(0)));
-    assert_eq!(expression!(1.5), Expression::Number(Number::from(1.5)));
+    assert_eq!(expression!(1.5), Expression::from(1.5));
     assert_eq!(expression!("foo"), Expression::String("foo".into()));
 }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -32,7 +32,7 @@ impl<'de> Deserialize<'de> for Value {
             }
 
             fn visit_f64<E>(self, value: f64) -> Result<Value, E> {
-                Ok(Value::Number(value.into()))
+                Ok(Number::from_f64(value).map_or(Value::Null, Value::Number))
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Value, E>
@@ -120,11 +120,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer {
         match self.value {
             Value::Null => visitor.visit_unit(),
             Value::Bool(b) => visitor.visit_bool(b),
-            Value::Number(n) => match n {
-                Number::PosInt(i) => visitor.visit_u64(i),
-                Number::NegInt(i) => visitor.visit_i64(i),
-                Number::Float(f) => visitor.visit_f64(f),
-            },
+            Value::Number(n) => n.deserialize_any(visitor),
             Value::String(s) => visitor.visit_string(s),
             Value::Array(array) => visitor.visit_seq(array.into_deserializer()),
             Value::Object(object) => visitor.visit_map(object.into_deserializer()),

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,4 +1,4 @@
-use super::{Map, Value};
+use super::{Map, Number, Value};
 use std::borrow::Cow;
 
 macro_rules! impl_from_integer {
@@ -18,13 +18,13 @@ impl_from_integer!(u8, u16, u32, u64, usize);
 
 impl From<f32> for Value {
     fn from(f: f32) -> Self {
-        Self::Number(f.into())
+        From::from(f as f64)
     }
 }
 
 impl From<f64> for Value {
     fn from(f: f64) -> Self {
-        Self::Number(f.into())
+        Number::from_f64(f).map_or(Value::Null, Value::Number)
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: The `Number` type was changed from an `enum` to an opaque `struct`. Use `Number::from` to create a number from an integer. Furthermore, the `From` implementations for `f32` and `f64` were removed. Use the newly added `Number::from_f64` instead.

This ensures that any number is finite and is almost identical to what `serde_json` does. Infinite floats get converted to `Value::Null` and `Expression::Null` respectively when working with the `Value` and `Expression` types.