### PR TITLE
fix(parser): panic when parsing `LegacyIndex` traversal operator

### DIFF
--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -463,3 +463,24 @@ fn issue_81() {
 
     assert_eq!(body, expected);
 }
+
+#[test]
+fn issue_83() {
+    let body: Body = crate::from_str("attr = module.instance.0.id").unwrap();
+
+    let expected = Body::builder()
+        .add_attribute((
+            "attr",
+            Traversal::new(
+                Identifier::new("module"),
+                [
+                    TraversalOperator::GetAttr("instance".into()),
+                    TraversalOperator::LegacyIndex(0),
+                    TraversalOperator::GetAttr("id".into()),
+                ],
+            ),
+        ))
+        .build();
+
+    assert_eq!(body, expected);
+}

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -108,7 +108,7 @@ Variable = @{ Identifier }
 
 // Index operator
 Index       =  { ("[" ~ Expression ~ "]") | LegacyIndex }
-LegacyIndex = ${ "." ~ Decimal+ }
+LegacyIndex = ${ "." ~ Int }
 
 // Attribute access operator
 GetAttr = ${ "." ~ Identifier }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -300,7 +300,9 @@ fn parse_traversal_operator(pair: Pair<Rule>) -> Result<TraversalOperator> {
             let pair = inner(pair);
 
             match pair.as_rule() {
-                Rule::LegacyIndex => TraversalOperator::LegacyIndex(parse_primitive::<u64>(pair)),
+                Rule::LegacyIndex => {
+                    TraversalOperator::LegacyIndex(parse_primitive::<u64>(inner(pair)))
+                }
                 _ => TraversalOperator::Index(parse_expression(pair)?),
             }
         }


### PR DESCRIPTION
Fixes #83

The leading `.` was included when attempting to parse the integer index, which rightfully failed.