### PR TITLE
fix(parser): greatly improve expression parsing performance

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -6,76 +6,6 @@ fn benchmark(c: &mut Criterion) {
     let body: Body = hcl::from_str(&input).unwrap();
     let value: Value = hcl::from_str(&input).unwrap();
 
-    let nested_arrays = r#"
-variable "test" {
-  level1 = [[[[[[[[[[[[]]]]]]]]]]]]
-}
-"#;
-
-    c.bench_function("hcl::parse(&nested_arrays)", |b| {
-        b.iter(|| hcl::parse(&nested_arrays))
-    });
-
-    let nested_objects = r#"
-variable "test" {
-  level1 = {
-    level2 = {
-      level3 = {
-        level4 = {
-          level5 = {
-            level6 = {
-              level7 = {
-                level8 = {
-                  level9 = {
-                    level10 = {
-                      level11 = {
-                        level12 = {
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-"#;
-
-    c.bench_function("hcl::parse(&nested_objects)", |b| {
-        b.iter(|| hcl::parse(&nested_objects))
-    });
-
-    let nested_func_calls = r#"
-variable "test" {
-  level1 = map(object({
-    level2 = map(object({
-      level3 = map(object({
-        level4 = map(object({
-        }))
-      }))
-    }))
-  }))
-}
-"#;
-
-    c.bench_function("hcl::parse(&nested_func_calls)", |b| {
-        b.iter(|| hcl::parse(&nested_func_calls))
-    });
-
-    let nested_func_calls2 = r#"
-variable "test" {
-  level1 = map(map(map(map(map(map(map(map(map(map(map(map())))))))))))
-}
-"#;
-
-    c.bench_function("hcl::parse(&nested_func_calls2)", |b| {
-        b.iter(|| hcl::parse(&nested_func_calls2))
-    });
-
     c.bench_function("hcl::parse", |b| b.iter(|| hcl::parse(&input)));
 
     c.bench_function("hcl::from_str::<Body>", |b| {
@@ -92,6 +22,39 @@ variable "test" {
 
     c.bench_function("hcl::to_string(&Value)", |b| {
         b.iter(|| hcl::to_string(&value))
+    });
+
+    let deeply_nested = r#"
+        variable "network_integration" {
+          description = "Map of networking integrations between accounts"
+          type = map(object({
+            friendly_name = string,
+            vpcs = map(object({
+              id           = string
+              cidr         = string
+              region       = string
+              description  = string
+              subnets      = map(string)
+              route_tables = map(string)
+              security_groups = map(object({
+                id = string
+                rules = map(object({
+                  direction   = string
+                  protocol    = string
+                  from_port   = string
+                  to_port     = string
+                  description = string
+                }))
+              }))
+            }))
+            additional_propagated_vpcs   = list(string)
+            additional_static_vpc_routes = list(string)
+          }))
+          default = {}
+        }"#;
+
+    c.bench_function("hcl::parse(&deeply_nested)", |b| {
+        b.iter(|| hcl::parse(&deeply_nested))
     });
 }
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -6,6 +6,76 @@ fn benchmark(c: &mut Criterion) {
     let body: Body = hcl::from_str(&input).unwrap();
     let value: Value = hcl::from_str(&input).unwrap();
 
+    let nested_arrays = r#"
+variable "test" {
+  level1 = [[[[[[[[[[[[]]]]]]]]]]]]
+}
+"#;
+
+    c.bench_function("hcl::parse(&nested_arrays)", |b| {
+        b.iter(|| hcl::parse(&nested_arrays))
+    });
+
+    let nested_objects = r#"
+variable "test" {
+  level1 = {
+    level2 = {
+      level3 = {
+        level4 = {
+          level5 = {
+            level6 = {
+              level7 = {
+                level8 = {
+                  level9 = {
+                    level10 = {
+                      level11 = {
+                        level12 = {
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+    c.bench_function("hcl::parse(&nested_objects)", |b| {
+        b.iter(|| hcl::parse(&nested_objects))
+    });
+
+    let nested_func_calls = r#"
+variable "test" {
+  level1 = map(object({
+    level2 = map(object({
+      level3 = map(object({
+        level4 = map(object({
+        }))
+      }))
+    }))
+  }))
+}
+"#;
+
+    c.bench_function("hcl::parse(&nested_func_calls)", |b| {
+        b.iter(|| hcl::parse(&nested_func_calls))
+    });
+
+    let nested_func_calls2 = r#"
+variable "test" {
+  level1 = map(map(map(map(map(map(map(map(map(map(map(map())))))))))))
+}
+"#;
+
+    c.bench_function("hcl::parse(&nested_func_calls2)", |b| {
+        b.iter(|| hcl::parse(&nested_func_calls2))
+    });
+
     c.bench_function("hcl::parse", |b| b.iter(|| hcl::parse(&input)));
 
     c.bench_function("hcl::from_str::<Body>", |b| {

--- a/specsuite/hcl/invalid-heredoc.hcl.json
+++ b/specsuite/hcl/invalid-heredoc.hcl.json
@@ -1,6 +1,6 @@
 {
   "message": "EOF must be immediately followed by a newline",
   "body": {
-    "message": " --> 2:12\n  |\n2 |   source = <<-EOF # This is invalid\n  |            ^---\n  |\n  = expected ExprTerm, Operation, or Conditional"
+    "message": " --> 2:12\n  |\n2 |   source = <<-EOF # This is invalid\n  |            ^---\n  |\n  = expected ExprTerm"
   }
 }

--- a/specsuite/hcl/invalid-heredoc.hcl.json
+++ b/specsuite/hcl/invalid-heredoc.hcl.json
@@ -1,6 +1,6 @@
 {
   "message": "EOF must be immediately followed by a newline",
   "body": {
-    "message": " --> 2:12\n  |\n2 |   source = <<-EOF # This is invalid\n  |            ^---\n  |\n  = expected ExprTerm"
+    "message": " --> 2:12\n  |\n2 |   source = <<-EOF # This is invalid\n  |            ^---\n  |\n  = expected Expression"
   }
 }

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -121,19 +121,12 @@ Splat     = _{ (AttrSplat ~ GetAttr*) | (FullSplat ~ (GetAttr | Index)*) }
 AttrSplat =  { ".*" }
 FullSplat =  { "[*]" }
 
-// Operations
-Operation          = { BinaryOp }
-UnaryOp            = { UnaryOperator ~ Expression }
+// Unary and binary operators
 UnaryOperator      = { "-" | "!" }
-BinaryOp           = { ExprTerm ~ BinaryOperator ~ Expression }
 BinaryOperator     = { CompareOperator | ArithmeticOperator | LogicOperator }
 CompareOperator    = { "==" | "!=" | "<=" | ">=" | "<" | ">" }
 ArithmeticOperator = { "+" | "-" | "*" | "/" | "%" }
 LogicOperator      = { "&&" | "||" }
-
-
-// Conditional operator
-Conditional =  { ExprTerm ~ "?" ~ Expression ~ ":" ~ Expression }
 
 // Comments
 COMMENT         = _{ InlineComment | BlockComment }

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -43,9 +43,11 @@ ExpMark    =  { ("e" | "E") ~ ("+" | "-")? }
 Decimal    =  { '0'..'9' }
 
 // Collection values
-CollectionValue = _{ Tuple | Object }
-Tuple           =  { "[" ~ (Expression ~ ("," ~ Expression)* ~ ","?)? ~ "]" }
-Object          =  { "{" ~ (ObjectItem ~ (","? ~ ObjectItem)* ~ ","?)? ~ "}" }
+CollectionValue = _{ EmptyTuple | EmptyObject | Tuple | Object }
+EmptyTuple      =  { "[" ~ "]" }
+Tuple           =  { "[" ~ Expression ~ ("," ~ Expression)* ~ ","? ~ "]" }
+EmptyObject     =  { "{" ~ "}" }
+Object          =  { "{" ~ ObjectItem ~ (","? ~ ObjectItem)* ~ ","? ~ "}" }
 ObjectItem      = _{ ObjectItemIdent | ObjectItemExpr }
 ObjectItemIdent = _{ Identifier ~ ("=" | ":") ~ Expression }
 ObjectItemExpr  = _{ Expression ~ ("=" | ":") ~ Expression }
@@ -84,16 +86,10 @@ StringPart = {
 }
 
 // Functions and function calls
-FunctionCall = ${
-    Identifier ~ "(" ~
-    WHITESPACE* ~ (COMMENT ~ WHITESPACE*)* ~
-    Arguments ~
-    WHITESPACE* ~ (COMMENT ~ WHITESPACE*)* ~
-    ")"
-}
-
-Arguments   = !{ (Expression ~ ("," ~ Expression)* ~ ("," | ExpandFinal)?)? }
-ExpandFinal =  { "..." }
+FunctionCall = { Identifier ~ (NoArguments | Arguments) }
+NoArguments  = { "(" ~ ")" }
+Arguments    = { "(" ~ Expression ~ ("," ~ Expression)* ~ ("," | ExpandFinal)? ~ ")" }
+ExpandFinal  = { "..." }
 
 // For expressions
 ForExpr       = { ForTupleExpr | ForObjectExpr }

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -50,11 +50,9 @@ ExpMark    =  { ("e" | "E") ~ ("+" | "-")? }
 Decimal    =  { '0'..'9' }
 
 // Collection values
-CollectionValue = _{ EmptyTuple | EmptyObject | Tuple | Object }
-EmptyTuple      =  { "[" ~ "]" }
-Tuple           =  { "[" ~ Expression ~ ("," ~ Expression)* ~ ","? ~ "]" }
-EmptyObject     =  { "{" ~ "}" }
-Object          =  { "{" ~ ObjectItem ~ (","? ~ ObjectItem)* ~ ","? ~ "}" }
+CollectionValue = _{ Tuple | Object }
+Tuple           =  { "[" ~ (Expression ~ ("," ~ Expression)* ~ ","?)? ~ "]" }
+Object          =  { "{" ~ (ObjectItem ~ (","? ~ ObjectItem)* ~ ","?)? ~ "}" }
 ObjectItem      = _{ ObjectItemIdent | ObjectItemExpr }
 ObjectItemIdent = _{ Identifier ~ ("=" | ":") ~ Expression }
 ObjectItemExpr  = _{ Expression ~ ("=" | ":") ~ Expression }
@@ -93,9 +91,8 @@ StringPart = {
 }
 
 // Functions and function calls
-FunctionCall = { Identifier ~ (NoArguments | Arguments) }
-NoArguments  = { "(" ~ ")" }
-Arguments    = { "(" ~ Expression ~ ("," ~ Expression)* ~ ("," | ExpandFinal)? ~ ")" }
+FunctionCall = { Identifier ~ Arguments }
+Arguments    = { "(" ~ (Expression ~ ("," ~ Expression)* ~ ("," | ExpandFinal)?)? ~ ")" }
 ExpandFinal  = { "..." }
 
 // For expressions

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -10,11 +10,17 @@ Block     = { Identifier ~ (StringLit | Identifier)* ~ BlockBody }
 BlockBody = { "{" ~ Body ~ "}" }
 
 // Expressions
-Expression    =  { ExprTerm ~ ("?" ~ Expression ~ ":" ~ Expression)? }
-ExprTerm      =  { UnaryOperator? ~ ExprTermInner ~ Traversal ~ (BinaryOperator ~ Expression)? }
-ExprTermInner = _{ Value | TemplateExpr | FunctionCall | Variable | ForExpr | Parenthesis }
-Parenthesis   =  { "(" ~ Expression ~ ")" }
-Traversal     =  { (Splat | GetAttr | Index)* }
+Expression = {
+    UnaryOperator? ~
+    ExprTerm ~
+    (BinaryOperator ~ Expression)? ~
+    ("?" ~ Expression ~ ":" ~ Expression)?
+}
+ExprTerm = {
+    (Value | TemplateExpr | FunctionCall | Variable | ForExpr | Parenthesis) ~
+    (Splat | GetAttr | Index)*
+}
+Parenthesis = { "(" ~ Expression ~ ")" }
 
 // Values
 Value = _{ LiteralValue | CollectionValue }

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -10,10 +10,11 @@ Block     = { Identifier ~ (StringLit | Identifier)* ~ BlockBody }
 BlockBody = { "{" ~ Body ~ "}" }
 
 // Expressions
-Expression    = _{ Conditional | Operation | ExprTerm }
-ExprTerm      =  { ExprTermInner ~ (Splat | GetAttr | Index)* }
+Expression    = _{ Conditional | ExprTerm }
+ExprTerm      =  { UnaryOperator? ~ ExprTermInner ~ Traversal ~ (BinaryOperator ~ Expression)? }
 ExprTermInner = _{ Value | TemplateExpr | FunctionCall | Variable | ForExpr | Parenthesis }
 Parenthesis   =  { "(" ~ Expression ~ ")" }
+Traversal     =  { (Splat | GetAttr | Index)* }
 
 // Values
 Value = _{ LiteralValue | CollectionValue }
@@ -115,7 +116,7 @@ AttrSplat =  { ".*" }
 FullSplat =  { "[*]" }
 
 // Operations
-Operation          = { UnaryOp | BinaryOp }
+Operation          = { BinaryOp }
 UnaryOp            = { UnaryOperator ~ Expression }
 UnaryOperator      = { "-" | "!" }
 BinaryOp           = { ExprTerm ~ BinaryOperator ~ Expression }
@@ -126,7 +127,7 @@ LogicOperator      = { "&&" | "||" }
 
 
 // Conditional operator
-CondExpr    = _{ ExprTerm | Operation }
+CondExpr    = _{ ExprTerm }
 Conditional =  { CondExpr ~ "?" ~ Expression ~ ":" ~ Expression }
 
 // Comments

--- a/src/parser/grammar/hcl.pest
+++ b/src/parser/grammar/hcl.pest
@@ -10,7 +10,7 @@ Block     = { Identifier ~ (StringLit | Identifier)* ~ BlockBody }
 BlockBody = { "{" ~ Body ~ "}" }
 
 // Expressions
-Expression    = _{ Conditional | ExprTerm }
+Expression    =  { ExprTerm ~ ("?" ~ Expression ~ ":" ~ Expression)? }
 ExprTerm      =  { UnaryOperator? ~ ExprTermInner ~ Traversal ~ (BinaryOperator ~ Expression)? }
 ExprTermInner = _{ Value | TemplateExpr | FunctionCall | Variable | ForExpr | Parenthesis }
 Parenthesis   =  { "(" ~ Expression ~ ")" }
@@ -127,8 +127,7 @@ LogicOperator      = { "&&" | "||" }
 
 
 // Conditional operator
-CondExpr    = _{ ExprTerm }
-Conditional =  { CondExpr ~ "?" ~ Expression ~ ":" ~ Expression }
+Conditional =  { ExprTerm ~ "?" ~ Expression ~ ":" ~ Expression }
 
 // Comments
 COMMENT         = _{ InlineComment | BlockComment }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -112,21 +112,18 @@ fn parse_block_body(pair: Pair<Rule>) -> Result<Body> {
 }
 
 fn parse_expression(pair: Pair<Rule>) -> Result<Expression> {
-    match pair.as_rule() {
-        Rule::ExprTerm => parse_expr_term(pair),
-        Rule::Conditional => Ok(Expression::from(parse_conditional(pair)?)),
-        rule => unexpected_rule(rule),
-    }
-}
-
-fn parse_conditional(pair: Pair<Rule>) -> Result<Conditional> {
     let mut pairs = pair.into_inner();
 
-    Ok(Conditional {
-        cond_expr: parse_expression(pairs.next().unwrap())?,
-        true_expr: parse_expression(pairs.next().unwrap())?,
-        false_expr: parse_expression(pairs.next().unwrap())?,
-    })
+    let expr_term = parse_expr_term(pairs.next().unwrap())?;
+
+    match pairs.next() {
+        Some(pair) => Ok(Expression::from(Conditional {
+            cond_expr: expr_term,
+            true_expr: parse_expression(pair)?,
+            false_expr: parse_expression(pairs.next().unwrap())?,
+        })),
+        None => Ok(expr_term),
+    }
 }
 
 fn parse_expressions(pair: Pair<Rule>) -> Result<Vec<Expression>> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -188,7 +188,9 @@ fn parse_expr_term(pair: Pair<Rule>) -> Result<Expression> {
             Expression::TemplateExpr(Box::new(expr))
         }
         Rule::Tuple => parse_expressions(pair).map(Expression::Array)?,
+        Rule::EmptyTuple => Expression::Array(Vec::new()),
         Rule::Object => parse_object(pair).map(Expression::Object)?,
+        Rule::EmptyObject => Expression::Object(Object::new()),
         Rule::Variable => Expression::Variable(parse_ident(pair).into()),
         Rule::FunctionCall => Expression::FuncCall(Box::new(parse_func_call(pair)?)),
         Rule::Parenthesis => Expression::Parenthesis(Box::new(parse_expression(inner(pair))?)),
@@ -281,14 +283,22 @@ fn parse_for_intro(pair: Pair<Rule>) -> Result<(Option<Identifier>, Identifier, 
 fn parse_func_call(pair: Pair<Rule>) -> Result<FuncCall> {
     let mut pairs = pair.into_inner();
     let name = pairs.next().unwrap();
-    let mut args = pairs.next().unwrap().into_inner();
-    let builder = FuncCall::builder(name.as_str());
+    let args = pairs.next().unwrap();
 
-    args.try_fold(builder, |builder, pair| match pair.as_rule() {
-        Rule::ExpandFinal => Ok(builder.expand_final(true)),
-        _ => Ok(builder.arg(parse_expression(pair)?)),
-    })
-    .map(FuncCallBuilder::build)
+    match args.as_rule() {
+        Rule::Arguments => {
+            let mut args = args.into_inner();
+            let builder = FuncCall::builder(name.as_str());
+
+            args.try_fold(builder, |builder, pair| match pair.as_rule() {
+                Rule::ExpandFinal => Ok(builder.expand_final(true)),
+                _ => Ok(builder.arg(parse_expression(pair)?)),
+            })
+            .map(FuncCallBuilder::build)
+        }
+        Rule::NoArguments => Ok(FuncCall::new(name.as_str())),
+        rule => unexpected_rule(rule),
+    }
 }
 
 fn parse_traversal_operator(pair: Pair<Rule>) -> Result<TraversalOperator> {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -50,7 +50,6 @@ fn parse_number() {
 }
 
 #[test]
-#[ignore]
 fn parse_attr() {
     parses_to! {
         parser: HclParser,
@@ -59,9 +58,11 @@ fn parse_attr() {
         tokens: [
             Attribute(0, 11, [
                 Identifier(0, 3),
-                ExprTerm(6, 11, [
-                    StringLit(6, 11, [
-                        String(7, 10)
+                Expression(6, 11, [
+                    ExprTerm(6, 11, [
+                        StringLit(6, 11, [
+                            String(7, 10)
+                        ])
                     ])
                 ])
             ])
@@ -70,25 +71,28 @@ fn parse_attr() {
 }
 
 #[test]
-#[ignore]
 fn conditional() {
     parses_to! {
         parser: HclParser,
         input: "var.enabled ? 1 : 0",
-        rule: Rule::Conditional,
+        rule: Rule::Expression,
         tokens: [
-            Conditional(0, 19, [
+            Expression(0, 19, [
                 ExprTerm(0, 11, [
                     Variable(0, 3),
                     GetAttr(3, 11, [
                         Identifier(4, 11)
                     ])
                 ]),
-                ExprTerm(14, 16, [
-                    Int(14, 15)
+                Expression(14, 16, [
+                    ExprTerm(14, 16, [
+                        Int(14, 15)
+                    ])
                 ]),
-                ExprTerm(18, 19, [
-                    Int(18, 19)
+                Expression(18, 19, [
+                    ExprTerm(18, 19, [
+                        Int(18, 19)
+                    ])
                 ])
             ])
         ]
@@ -96,7 +100,6 @@ fn conditional() {
 }
 
 #[test]
-#[ignore]
 fn parse_terraform() {
     parses_to! {
         parser: HclParser,
@@ -130,16 +133,20 @@ resource "aws_s3_bucket" "mybucket" {
                         Body(41, 297, [
                             Attribute(41, 70, [
                                 Identifier(41, 47),
-                                ExprTerm(57, 70, [
-                                    StringLit(57, 67, [
-                                        String(58, 66)
+                                Expression(57, 70, [
+                                    ExprTerm(57, 70, [
+                                        StringLit(57, 67, [
+                                            String(58, 66)
+                                        ])
                                     ])
                                 ])
                             ]),
                             Attribute(70, 94, [
                                 Identifier(70, 83),
-                                ExprTerm(86, 94, [
-                                    BooleanLit(86, 90)
+                                Expression(86, 94, [
+                                    ExprTerm(86, 94, [
+                                        BooleanLit(86, 90)
+                                    ])
                                 ])
                             ]),
                             Block(94, 297, [
@@ -154,23 +161,27 @@ resource "aws_s3_bucket" "mybucket" {
                                                         Identifier(150, 189),
                                                         BlockBody(190, 287, [
                                                             Body(200, 286, [
-                                                                Attribute(200, 241, [
+                                                                Attribute(200, 250, [
                                                                     Identifier(200, 217),
-                                                                    ExprTerm(220, 241, [
-                                                                        Variable(220, 231),
-                                                                        GetAttr(231, 237, [
-                                                                            Identifier(232, 237)
-                                                                        ]),
-                                                                        GetAttr(237, 241, [
-                                                                            Identifier(238, 241)
+                                                                    Expression(220, 250, [
+                                                                        ExprTerm(220, 241, [
+                                                                            Variable(220, 231),
+                                                                            GetAttr(231, 237, [
+                                                                                Identifier(232, 237)
+                                                                            ]),
+                                                                            GetAttr(237, 241, [
+                                                                                Identifier(238, 241)
+                                                                            ])
                                                                         ])
                                                                     ])
                                                                 ]),
                                                                 Attribute(250, 286, [
                                                                     Identifier(250, 263),
-                                                                    ExprTerm(270, 286, [
-                                                                        StringLit(270, 279, [
-                                                                            String(271, 278)
+                                                                    Expression(270, 286, [
+                                                                        ExprTerm(270, 286, [
+                                                                            StringLit(270, 279, [
+                                                                                String(271, 278)
+                                                                            ])
                                                                         ])
                                                                     ])
                                                                 ])
@@ -192,7 +203,6 @@ resource "aws_s3_bucket" "mybucket" {
 }
 
 #[test]
-#[ignore]
 fn parse_collections() {
     parses_to! {
         parser: HclParser,
@@ -201,18 +211,26 @@ fn parse_collections() {
         tokens: [
             Attribute(0, 22, [
                 Identifier(0, 3),
-                ExprTerm(6, 22, [
-                    Tuple(6, 22, [
-                        ExprTerm(7, 12, [
-                            StringLit(7, 12, [
-                                String(8, 11)
-                            ])
-                        ]),
-                        ExprTerm(14, 21, [
-                            Tuple(14, 21, [
-                                ExprTerm(15, 20, [
-                                    StringLit(15, 20, [
-                                        String(16, 19)
+                Expression(6, 22, [
+                    ExprTerm(6, 22, [
+                        Tuple(6, 22, [
+                            Expression(7, 12, [
+                                ExprTerm(7, 12, [
+                                    StringLit(7, 12, [
+                                        String(8, 11)
+                                    ])
+                                ])
+                            ]),
+                            Expression(14, 21, [
+                                ExprTerm(14, 21, [
+                                    Tuple(14, 21, [
+                                        Expression(15, 20, [
+                                            ExprTerm(15, 20, [
+                                                StringLit(15, 20, [
+                                                    String(16, 19)
+                                                ])
+                                            ])
+                                        ])
                                     ])
                                 ])
                             ])
@@ -230,25 +248,35 @@ fn parse_collections() {
         tokens: [
             Attribute(0, 36, [
                 Identifier(0, 3),
-                ExprTerm(6, 36, [
-                    Object(6, 36, [
-                        ExprTerm(7, 13, [
-                            StringLit(7, 12, [
-                                String(8, 11)
+                Expression(6, 36, [
+                    ExprTerm(6, 36, [
+                        Object(6, 36, [
+                            Expression(7, 13, [
+                                ExprTerm(7, 13, [
+                                    StringLit(7, 12, [
+                                        String(8, 11)
+                                    ])
+                                ])
+                            ]),
+                            Expression(15, 20, [
+                                ExprTerm(15, 20, [
+                                    StringLit(15, 20, [
+                                        String(16, 19)
+                                    ])
+                                ])
+                            ]),
+                            Expression(21, 27, [
+                                ExprTerm(21, 27, [
+                                    StringLit(21, 26, [
+                                        String(22, 25)
+                                    ])
+                                ])
+                            ]),
+                            Expression(29, 35, [
+                                ExprTerm(29, 35, [
+                                    Variable(29, 34)
+                                ])
                             ])
-                        ]),
-                        ExprTerm(15, 20, [
-                            StringLit(15, 20, [
-                                String(16, 19)
-                            ])
-                        ]),
-                        ExprTerm(21, 27, [
-                            StringLit(21, 26, [
-                                String(22, 25)
-                            ])
-                        ]),
-                        ExprTerm(29, 35, [
-                            Variable(29, 34)
                         ])
                     ])
                 ])
@@ -258,7 +286,6 @@ fn parse_collections() {
 }
 
 #[test]
-#[ignore]
 fn parse_template() {
     parses_to! {
         parser: HclParser,
@@ -289,8 +316,10 @@ fn parse_template() {
                             QuotedStringTemplateLiteral(1, 5),
                             TemplateInterpolation(5, 11, [
                                 TemplateIExprStartNormal(5, 7),
-                                ExprTerm(7, 10, [
-                                    Variable(7, 10)
+                                Expression(7, 10, [
+                                    ExprTerm(7, 10, [
+                                        Variable(7, 10)
+                                    ])
                                 ]),
                                 TemplateExprEndNormal(10, 11)
                             ]),
@@ -299,8 +328,10 @@ fn parse_template() {
                                 TemplateIf(21, 48, [
                                     TemplateIfExpr(21, 38, [
                                         TemplateDExprStartNormal(21, 23),
-                                        ExprTerm(26, 31, [
-                                            Variable(26, 30)
+                                        Expression(26, 31, [
+                                            ExprTerm(26, 31, [
+                                                Variable(26, 30)
+                                            ])
                                         ]),
                                         TemplateExprEndStrip(31, 33),
                                         Template(34, 38, [
@@ -322,7 +353,6 @@ fn parse_template() {
 }
 
 #[test]
-#[ignore]
 fn parse_cond_in_interpolation() {
     parses_to! {
         parser: HclParser,
@@ -331,31 +361,37 @@ fn parse_cond_in_interpolation() {
         tokens: [
             Attribute(0, 37, [
                 Identifier(0, 4),
-                ExprTerm(7, 37, [
-                    TemplateExpr(7, 37, [
-                        QuotedStringTemplate(7, 37, [
-                            QuotedStringTemplateInner(8, 36, [
-                                TemplateInterpolation(8, 36, [
-                                    TemplateIExprStartNormal(8, 10),
-                                    Conditional(10, 35, [
-                                        ExprTerm(10, 15, [
-                                            Variable(10, 13),
-                                            GetAttr(13, 15, [
-                                                Identifier(14, 15)
+                Expression(7, 37, [
+                    ExprTerm(7, 37, [
+                        TemplateExpr(7, 37, [
+                            QuotedStringTemplate(7, 37, [
+                                QuotedStringTemplateInner(8, 36, [
+                                    TemplateInterpolation(8, 36, [
+                                        TemplateIExprStartNormal(8, 10),
+                                        Expression(10, 35, [
+                                            ExprTerm(10, 15, [
+                                                Variable(10, 13),
+                                                GetAttr(13, 15, [
+                                                    Identifier(14, 15)
+                                                ])
+                                            ]),
+                                            Expression(18, 31, [
+                                                ExprTerm(18, 31, [
+                                                    StringLit(18, 30, [
+                                                        String(19, 29)
+                                                    ])
+                                                ])
+                                            ]),
+                                            Expression(33, 35, [
+                                                ExprTerm(33, 35, [
+                                                    StringLit(33, 35, [
+                                                        String(34, 34)
+                                                    ])
+                                                ])
                                             ])
                                         ]),
-                                        ExprTerm(18, 31, [
-                                            StringLit(18, 30, [
-                                                String(19, 29)
-                                            ])
-                                        ]),
-                                        ExprTerm(33, 35, [
-                                            StringLit(33, 35, [
-                                                String(34, 34)
-                                            ])
-                                        ])
-                                    ]),
-                                    TemplateExprEndNormal(35, 36)
+                                        TemplateExprEndNormal(35, 36)
+                                    ])
                                 ])
                             ])
                         ])
@@ -367,7 +403,6 @@ fn parse_cond_in_interpolation() {
 }
 
 #[test]
-#[ignore]
 fn parse_object_with_variable_expr_key() {
     parses_to! {
         parser: HclParser,
@@ -381,30 +416,40 @@ providers = {
             Body(1, 89, [
                 Attribute(1, 89, [
                     Identifier(1, 10),
-                    ExprTerm(13, 89, [
-                        Object(13, 89, [
-                            ExprTerm(17, 33, [
-                                Variable(17, 20),
-                                GetAttr(20, 33, [
-                                    Identifier(21, 33)
+                    Expression(13, 89, [
+                        ExprTerm(13, 89, [
+                            Object(13, 89, [
+                                Expression(17, 34, [
+                                    ExprTerm(17, 33, [
+                                        Variable(17, 20),
+                                        GetAttr(20, 33, [
+                                            Identifier(21, 33)
+                                        ]),
+                                    ])
                                 ]),
-                            ]),
-                            ExprTerm(36, 52, [
-                                Variable(36, 39),
-                                GetAttr(39, 52, [
-                                    Identifier(40, 52)
+                                Expression(36, 55, [
+                                    ExprTerm(36, 52, [
+                                        Variable(36, 39),
+                                        GetAttr(39, 52, [
+                                            Identifier(40, 52)
+                                        ]),
+                                    ])
                                 ]),
-                            ]),
-                            ExprTerm(55, 68, [
-                                Variable(55, 58),
-                                GetAttr(58, 68, [
-                                    Identifier(59, 68)
+                                Expression(55, 72, [
+                                    ExprTerm(55, 68, [
+                                        Variable(55, 58),
+                                        GetAttr(58, 68, [
+                                            Identifier(59, 68)
+                                        ]),
+                                    ])
                                 ]),
-                            ]),
-                            ExprTerm(74, 87, [
-                                Variable(74, 77),
-                                GetAttr(77, 87, [
-                                    Identifier(78, 87)
+                                Expression(74, 88, [
+                                    ExprTerm(74, 87, [
+                                        Variable(74, 77),
+                                        GetAttr(77, 87, [
+                                            Identifier(78, 87)
+                                        ])
+                                    ])
                                 ])
                             ])
                         ])
@@ -416,7 +461,6 @@ providers = {
 }
 
 #[test]
-#[ignore]
 fn parse_nested_function_call_with_splat() {
     parses_to! {
         parser: HclParser,
@@ -426,35 +470,43 @@ fn parse_nested_function_call_with_splat() {
             FunctionCall(0, 72, [
                 Identifier(0, 7),
                 Arguments(7, 72, [
-                    ExprTerm(8, 68, [
-                        FunctionCall(8, 68, [
-                            Identifier(8, 14),
-                            Arguments(14, 68, [
-                                ExprTerm(15, 40, [
-                                    Variable(15, 26),
-                                    GetAttr(26, 34, [
-                                        Identifier(27, 34)
+                    Expression(8, 68, [
+                        ExprTerm(8, 68, [
+                            FunctionCall(8, 68, [
+                                Identifier(8, 14),
+                                Arguments(14, 68, [
+                                    Expression(15, 40, [
+                                        ExprTerm(15, 40, [
+                                            Variable(15, 26),
+                                            GetAttr(26, 34, [
+                                                Identifier(27, 34)
+                                            ]),
+                                            AttrSplat(34, 36),
+                                            GetAttr(36, 40, [
+                                                Identifier(37, 40)
+                                            ]),
+                                        ])
                                     ]),
-                                    AttrSplat(34, 36),
-                                    GetAttr(36, 40, [
-                                        Identifier(37, 40)
-                                    ]),
-                                ]),
-                                ExprTerm(42, 67, [
-                                    Variable(42, 53),
-                                    GetAttr(53, 61, [
-                                        Identifier(54, 61)
-                                    ]),
-                                    AttrSplat(61, 63),
-                                    GetAttr(63, 67, [
-                                        Identifier(64, 67)
+                                    Expression(42, 67, [
+                                        ExprTerm(42, 67, [
+                                            Variable(42, 53),
+                                            GetAttr(53, 61, [
+                                                Identifier(54, 61)
+                                            ]),
+                                            AttrSplat(61, 63),
+                                            GetAttr(63, 67, [
+                                                Identifier(64, 67)
+                                            ])
+                                        ])
                                     ])
                                 ])
                             ])
                         ])
                     ]),
-                    ExprTerm(70, 71, [
-                        Int(70, 71)
+                    Expression(70, 71, [
+                        ExprTerm(70, 71, [
+                            Int(70, 71)
+                        ])
                     ])
                 ])
             ])
@@ -463,7 +515,6 @@ fn parse_nested_function_call_with_splat() {
 }
 
 #[test]
-#[ignore]
 fn parse_traversal_with_expression() {
     parses_to! {
         parser: HclParser,
@@ -472,14 +523,14 @@ fn parse_traversal_with_expression() {
         tokens: [
             Attribute(0, 86, [
                 Identifier(0, 14),
-                ExprTerm(17, 86, [
-                    Variable(17, 32),
-                    GetAttr(32, 40, [
-                        Identifier(33, 40)
-                    ]),
-                    Index(40, 83, [
-                        Operation(41, 82, [
-                            BinaryOp(41, 82, [
+                Expression(17, 86, [
+                    ExprTerm(17, 86, [
+                        Variable(17, 32),
+                        GetAttr(32, 40, [
+                            Identifier(33, 40)
+                        ]),
+                        Index(40, 83, [
+                            Expression(41, 82, [
                                 ExprTerm(41, 52, [
                                     Variable(41, 46),
                                     GetAttr(46, 52, [
@@ -489,17 +540,19 @@ fn parse_traversal_with_expression() {
                                 BinaryOperator(53, 54, [
                                     ArithmeticOperator(53, 54)
                                 ]),
-                                ExprTerm(55, 82, [
-                                    Variable(55, 58),
-                                    GetAttr(58, 82, [
-                                        Identifier(59, 82)
-                                    ]),
+                                Expression(55, 82, [
+                                    ExprTerm(55, 82, [
+                                        Variable(55, 58),
+                                        GetAttr(58, 82, [
+                                            Identifier(59, 82)
+                                        ]),
+                                    ])
                                 ])
                             ])
+                        ]),
+                        GetAttr(83, 86, [
+                            Identifier(84, 86)
                         ])
-                    ]),
-                    GetAttr(83, 86, [
-                        Identifier(84, 86)
                     ])
                 ])
             ])
@@ -508,7 +561,6 @@ fn parse_traversal_with_expression() {
 }
 
 #[test]
-#[ignore]
 fn parse_null_in_variable_expr() {
     parses_to! {
         parser: HclParser,
@@ -517,8 +569,10 @@ fn parse_null_in_variable_expr() {
         tokens: [
             Attribute(0, 14, [
                 Identifier(0, 3),
-                ExprTerm(6, 14, [
-                    Variable(6, 14)
+                Expression(6, 14, [
+                    ExprTerm(6, 14, [
+                        Variable(6, 14)
+                    ])
                 ])
             ])
         ]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -417,11 +417,11 @@ fn parse_nested_function_call_with_splat() {
         tokens: [
             FunctionCall(0, 72, [
                 Identifier(0, 7),
-                Arguments(8, 71, [
+                Arguments(7, 72, [
                     ExprTerm(8, 68, [
                         FunctionCall(8, 68, [
                             Identifier(8, 14),
-                            Arguments(15, 67, [
+                            Arguments(14, 68, [
                                 ExprTerm(15, 40, [
                                     Variable(15, 26),
                                     GetAttr(26, 34, [

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -50,6 +50,7 @@ fn parse_number() {
 }
 
 #[test]
+#[ignore]
 fn parse_attr() {
     parses_to! {
         parser: HclParser,
@@ -69,6 +70,7 @@ fn parse_attr() {
 }
 
 #[test]
+#[ignore]
 fn conditional() {
     parses_to! {
         parser: HclParser,
@@ -94,6 +96,7 @@ fn conditional() {
 }
 
 #[test]
+#[ignore]
 fn parse_terraform() {
     parses_to! {
         parser: HclParser,
@@ -189,6 +192,7 @@ resource "aws_s3_bucket" "mybucket" {
 }
 
 #[test]
+#[ignore]
 fn parse_collections() {
     parses_to! {
         parser: HclParser,
@@ -254,6 +258,7 @@ fn parse_collections() {
 }
 
 #[test]
+#[ignore]
 fn parse_template() {
     parses_to! {
         parser: HclParser,
@@ -317,6 +322,7 @@ fn parse_template() {
 }
 
 #[test]
+#[ignore]
 fn parse_cond_in_interpolation() {
     parses_to! {
         parser: HclParser,
@@ -361,6 +367,7 @@ fn parse_cond_in_interpolation() {
 }
 
 #[test]
+#[ignore]
 fn parse_object_with_variable_expr_key() {
     parses_to! {
         parser: HclParser,
@@ -409,6 +416,7 @@ providers = {
 }
 
 #[test]
+#[ignore]
 fn parse_nested_function_call_with_splat() {
     parses_to! {
         parser: HclParser,
@@ -455,6 +463,7 @@ fn parse_nested_function_call_with_splat() {
 }
 
 #[test]
+#[ignore]
 fn parse_traversal_with_expression() {
     parses_to! {
         parser: HclParser,
@@ -499,6 +508,7 @@ fn parse_traversal_with_expression() {
 }
 
 #[test]
+#[ignore]
 fn parse_null_in_variable_expr() {
     parses_to! {
         parser: HclParser,


### PR DESCRIPTION
Previously, the parser needed to do a lot of backtracking while parsing conditionals and operations which massively degraded performance for deeply nested expressions.

This fix inlines the handling for operations and conditionals into the `Expression` rule so that an already matched `ExprTerm` rule does not need to be re-evaluated when no operation/conditional is matched (which is the case in the vast majority of cases since literal values and collections are way more common than these.

Fixes #82 