### PR TITLE
fix(format): identifiers starting with underscores are valid

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -263,9 +263,12 @@ where
         }
 
         let mut chars = ident.chars();
-        let first = chars.next().unwrap();
+        let start = chars.next().unwrap();
 
-        if !is_xid_start(first) || !chars.all(|ch| ch == '-' || is_xid_continue(ch)) {
+        let start_valid = start == '_' || is_xid_start(start);
+        let continue_valid = chars.all(|ch| ch == '-' || is_xid_continue(ch));
+
+        if !start_valid || !continue_valid {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "invalid identifier",

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{Expression, FuncCall};
+use crate::{Attribute, Expression, FuncCall};
 
 #[test]
 fn issue_87() {
@@ -12,4 +12,12 @@ fn issue_87() {
     let result = to_string(&expr).unwrap();
 
     assert_eq!(result, "foo({\"bar\" = baz()})")
+}
+
+#[test]
+fn issue_91() {
+    let attr = Attribute::new("_foo", "bar");
+    let result = to_string(&attr).unwrap();
+
+    assert_eq!(result, "_foo = \"bar\"\n")
 }


### PR DESCRIPTION
Fixes #91