### PR TITLE
fix!: change `Attribute` key field type to `Identifier`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -73,7 +73,7 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute> {
     let mut pairs = pair.into_inner();
 
     Ok(Attribute {
-        key: parse_ident(pairs.next().unwrap()).into_inner(),
+        key: parse_ident(pairs.next().unwrap()),
         expr: parse_expression(pairs.next().unwrap())?,
     })
 }

--- a/src/structure/attribute.rs
+++ b/src/structure/attribute.rs
@@ -1,6 +1,6 @@
 //! Types to represent and build HCL attributes.
 
-use super::{Expression, Value};
+use super::{Expression, Identifier, Value};
 use serde::{Deserialize, Serialize};
 use std::iter;
 
@@ -18,7 +18,7 @@ use std::iter;
 #[serde(rename = "$hcl::attribute")]
 pub struct Attribute {
     /// The HCL attribute's key.
-    pub key: String,
+    pub key: Identifier,
     /// The value expression of the HCL attribute.
     pub expr: Expression,
 }
@@ -28,7 +28,7 @@ impl Attribute {
     /// attribute value that is convertible into an `Expression`.
     pub fn new<K, V>(key: K, expr: V) -> Attribute
     where
-        K: Into<String>,
+        K: Into<Identifier>,
         V: Into<Expression>,
     {
         Attribute {
@@ -56,10 +56,10 @@ impl From<Attribute> for Value {
 
 impl<K, V> From<(K, V)> for Attribute
 where
-    K: Into<String>,
+    K: Into<Identifier>,
     V: Into<Expression>,
 {
-    fn from(pair: (K, V)) -> Attribute {
-        Attribute::new(pair.0.into(), pair.1.into())
+    fn from((key, expr): (K, V)) -> Attribute {
+        Attribute::new(key, expr)
     }
 }

--- a/src/structure/de.rs
+++ b/src/structure/de.rs
@@ -87,7 +87,7 @@ impl<'de> IntoDeserializer<'de, Error> for Attribute {
 }
 
 pub struct AttributeAccess {
-    key: Option<String>,
+    key: Option<Identifier>,
     expr: Option<Expression>,
 }
 

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -358,7 +358,7 @@ impl IntoNodeMap for Body {
         self.into_iter().fold(Map::new(), |mut map, structure| {
             match structure {
                 Structure::Attribute(attr) => {
-                    map.insert(attr.key, Node::Value(attr.expr.into()));
+                    map.insert(attr.key.into(), Node::Value(attr.expr.into()));
                 }
                 Structure::Block(block) => {
                     block

--- a/src/structure/ser/body.rs
+++ b/src/structure/ser/body.rs
@@ -1,8 +1,8 @@
 use super::{
     attribute::SerializeAttributeStruct, block::SerializeBlockStruct,
-    expression::ExpressionSerializer, structure::*, StringSerializer,
+    expression::ExpressionSerializer, structure::*, IdentifierSerializer,
 };
-use crate::{Attribute, Body, Error, Result, Structure};
+use crate::{Attribute, Body, Error, Identifier, Result, Structure};
 use serde::ser::{self, Serialize, SerializeMap};
 
 pub struct BodySerializer;
@@ -55,7 +55,7 @@ impl ser::Serializer for BodySerializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        Ok(SerializeBodyTupleVariant::new(variant, len))
+        SerializeBodyTupleVariant::new(variant, len)
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
@@ -73,7 +73,7 @@ impl ser::Serializer for BodySerializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        Ok(SerializeBodyStructVariant::new(variant, len))
+        SerializeBodyStructVariant::new(variant, len)
     }
 }
 
@@ -119,10 +119,10 @@ pub struct SerializeBodyTupleVariant {
 }
 
 impl SerializeBodyTupleVariant {
-    pub fn new(variant: &'static str, len: usize) -> Self {
-        SerializeBodyTupleVariant {
-            inner: SerializeStructureTupleVariant::new(variant, len),
-        }
+    pub fn new(variant: &'static str, len: usize) -> Result<Self> {
+        Ok(SerializeBodyTupleVariant {
+            inner: SerializeStructureTupleVariant::new(variant, len)?,
+        })
     }
 }
 
@@ -132,7 +132,7 @@ impl ser::SerializeTupleVariant for SerializeBodyTupleVariant {
 
 pub struct SerializeBodyMap {
     structures: Vec<Structure>,
-    next_key: Option<String>,
+    next_key: Option<Identifier>,
 }
 
 impl SerializeBodyMap {
@@ -152,7 +152,7 @@ impl ser::SerializeMap for SerializeBodyMap {
     where
         T: ?Sized + ser::Serialize,
     {
-        self.next_key = Some(key.serialize(StringSerializer)?);
+        self.next_key = Some(key.serialize(IdentifierSerializer)?);
         Ok(())
     }
 
@@ -217,10 +217,10 @@ pub struct SerializeBodyStructVariant {
 }
 
 impl SerializeBodyStructVariant {
-    pub fn new(variant: &'static str, len: usize) -> Self {
-        SerializeBodyStructVariant {
-            inner: SerializeStructureStructVariant::new(variant, len),
-        }
+    pub fn new(variant: &'static str, len: usize) -> Result<Self> {
+        Ok(SerializeBodyStructVariant {
+            inner: SerializeStructureStructVariant::new(variant, len)?,
+        })
     }
 }
 

--- a/src/structure/ser/structure.rs
+++ b/src/structure/ser/structure.rs
@@ -56,7 +56,7 @@ impl ser::Serializer for StructureSerializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        Ok(SerializeStructureTupleVariant::new(variant, len))
+        SerializeStructureTupleVariant::new(variant, len)
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
@@ -74,7 +74,7 @@ impl ser::Serializer for StructureSerializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        Ok(SerializeStructureStructVariant::new(variant, len))
+        SerializeStructureStructVariant::new(variant, len)
     }
 }
 
@@ -129,10 +129,10 @@ pub struct SerializeStructureTupleVariant {
 }
 
 impl SerializeStructureTupleVariant {
-    pub fn new(variant: &'static str, len: usize) -> Self {
-        SerializeStructureTupleVariant {
-            inner: SerializeAttributeTupleVariant::new(variant, len),
-        }
+    pub fn new(variant: &'static str, len: usize) -> Result<Self> {
+        Ok(SerializeStructureTupleVariant {
+            inner: SerializeAttributeTupleVariant::new(variant, len)?,
+        })
     }
 }
 
@@ -204,10 +204,10 @@ pub struct SerializeStructureStructVariant {
 }
 
 impl SerializeStructureStructVariant {
-    pub fn new(variant: &'static str, len: usize) -> Self {
-        SerializeStructureStructVariant {
-            inner: SerializeAttributeStructVariant::new(variant, len),
-        }
+    pub fn new(variant: &'static str, len: usize) -> Result<Self> {
+        Ok(SerializeStructureStructVariant {
+            inner: SerializeAttributeStructVariant::new(variant, len)?,
+        })
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: The `Attribute` struct's `key` field type was changed from `String` to `Identifier`. Furthermore, the trait bound for the attribute key on `Attribute::new` changed from `Into<String>` to `Into<Identifier>`.