### PR TITLE
fix!: sanitize identifiers upon creation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     /// Represents errors due to invalid unicode code points that may occur when unescaping
     /// user-provided strings.
     InvalidUnicodeCodePoint(String),
+
+    /// Represents errors that resulted from identifiers that are not valid in HCL.
+    InvalidIdentifier(String),
 }
 
 impl Error {
@@ -75,6 +78,7 @@ impl Display for Error {
             Error::InvalidUnicodeCodePoint(u) => {
                 write!(f, "invalid unicode code point '\\u{}'", u)
             }
+            Error::InvalidIdentifier(ident) => write!(f, "invalid identifier `{}`", ident),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -73,7 +73,7 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute> {
     let mut pairs = pair.into_inner();
 
     Ok(Attribute {
-        key: parse_ident(pairs.next().unwrap()),
+        key: parse_ident(pairs.next().unwrap()).into_inner(),
         expr: parse_expression(pairs.next().unwrap())?,
     })
 }
@@ -81,7 +81,7 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute> {
 fn parse_block(pair: Pair<Rule>) -> Result<Block> {
     let mut pairs = pair.into_inner();
 
-    let identifier = parse_ident(pairs.next().unwrap());
+    let identifier = parse_ident(pairs.next().unwrap()).into_inner();
 
     let (labels, block_body): (Vec<Pair<Rule>>, Vec<Pair<Rule>>) =
         pairs.partition(|pair| pair.as_rule() != Rule::BlockBody);
@@ -98,7 +98,7 @@ fn parse_block(pair: Pair<Rule>) -> Result<Block> {
 
 fn parse_block_label(pair: Pair<Rule>) -> Result<BlockLabel> {
     match pair.as_rule() {
-        Rule::Identifier => Ok(BlockLabel::identifier(parse_ident(pair))),
+        Rule::Identifier => Ok(BlockLabel::Identifier(parse_ident(pair))),
         Rule::StringLit => parse_string(inner(pair)).map(BlockLabel::String),
         rule => unexpected_rule(rule),
     }
@@ -184,7 +184,7 @@ fn parse_expr_term(pair: Pair<Rule>) -> Result<Expression> {
         Rule::TemplateExpr => Expression::TemplateExpr(Box::new(parse_template_expr(inner(pair)))),
         Rule::Tuple => parse_expressions(pair).map(Expression::Array)?,
         Rule::Object => parse_object(pair).map(Expression::Object)?,
-        Rule::Variable => Expression::Variable(parse_ident(pair).into()),
+        Rule::Variable => Expression::Variable(parse_ident(pair)),
         Rule::FunctionCall => Expression::FuncCall(Box::new(parse_func_call(pair)?)),
         Rule::Parenthesis => Expression::Parenthesis(Box::new(parse_expression(inner(pair))?)),
         Rule::ForExpr => Expression::from(parse_for_expr(inner(pair))?),
@@ -263,13 +263,13 @@ fn parse_for_object_expr(pair: Pair<Rule>) -> Result<ForExpr> {
 fn parse_for_intro(pair: Pair<Rule>) -> Result<(Option<Identifier>, Identifier, Expression)> {
     let mut pairs = pair.into_inner();
     let value = pairs.next().unwrap();
-    let mut value_var = Some(Identifier::new(value.as_str()));
+    let mut value_var = Some(parse_ident(value));
     let mut expr = pairs.next().unwrap();
 
     // If there are two identifiers, the first one is the key and the second one the value.
     let key_var = match expr.as_rule() {
         Rule::Identifier => {
-            let key = value_var.replace(Identifier::new(expr.as_str()));
+            let key = value_var.replace(parse_ident(expr));
             expr = pairs.next().unwrap();
             key
         }
@@ -296,7 +296,7 @@ fn parse_traversal_operator(pair: Pair<Rule>) -> Result<TraversalOperator> {
     let operator = match pair.as_rule() {
         Rule::AttrSplat => TraversalOperator::AttrSplat,
         Rule::FullSplat => TraversalOperator::FullSplat,
-        Rule::GetAttr => TraversalOperator::GetAttr(parse_ident(inner(pair)).into()),
+        Rule::GetAttr => TraversalOperator::GetAttr(parse_ident(inner(pair))),
         Rule::Index => {
             let pair = inner(pair);
 
@@ -332,7 +332,7 @@ fn parse_object(pair: Pair<Rule>) -> Result<Object<ObjectKey, Expression>> {
 
 fn parse_object_key(pair: Pair<Rule>) -> Result<ObjectKey> {
     match pair.as_rule() {
-        Rule::Identifier => Ok(ObjectKey::identifier(parse_ident(pair))),
+        Rule::Identifier => Ok(ObjectKey::Identifier(parse_ident(pair))),
         _ => parse_expression(pair).map(ObjectKey::Expression),
     }
 }
@@ -353,8 +353,8 @@ fn parse_string(pair: Pair<Rule>) -> Result<String> {
     unescape(pair.as_str()).map(|c| c.to_string())
 }
 
-fn parse_ident(pair: Pair<Rule>) -> String {
-    pair.as_str().to_owned()
+fn parse_ident(pair: Pair<Rule>) -> Identifier {
+    Identifier::new_unchecked(pair.as_str())
 }
 
 fn parse_heredoc(pair: Pair<Rule>) -> Heredoc {
@@ -371,7 +371,7 @@ fn parse_heredoc(pair: Pair<Rule>) -> Heredoc {
 
     Heredoc {
         strip,
-        delimiter: Identifier::new(delimiter.as_str()),
+        delimiter: parse_ident(delimiter),
         template: template.as_str().to_owned(),
     }
 }

--- a/src/parser/template.rs
+++ b/src/parser/template.rs
@@ -130,13 +130,13 @@ struct ForExpr {
 fn parse_for_expr(pair: Pair<Rule>) -> Result<ForExpr> {
     let mut pairs = pair.into_inner();
     let start = pairs.next().unwrap();
-    let mut value_var = Some(Identifier::new(pairs.next().unwrap().as_str()));
+    let mut value_var = Some(parse_ident(pairs.next().unwrap()));
     let mut expr = pairs.next().unwrap();
 
     // If there are two identifiers, the first one is the key and the second one the value.
     let key_var = match expr.as_rule() {
         Rule::Identifier => {
-            let key_var = value_var.replace(Identifier::new(expr.as_str()));
+            let key_var = value_var.replace(parse_ident(expr));
             expr = pairs.next().unwrap();
             key_var
         }


### PR DESCRIPTION
BREAKING CHANGE: The trait bound of `Identifier::new` changed from `Into<String>` to `AsRef<str>` and the inner `String` field of `Identifier` is now private to prevent direct modification.

For most use cases this change shouldn't cause any issues. Identifiers are now automatically sanitized upon creation via `Identifier::new`. With `Identifier::from_str` a fallible alternative is provided in order to detect invalid identifiers. Furthermore `Identifier::new_unchecked` allows the creation of identifier without any validation. This can skip the sanitization if the caller already knows that the identifier is valid.