### PR TITLE
fix!: change `Block` identifier field type to `Identifier`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -81,7 +81,7 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute> {
 fn parse_block(pair: Pair<Rule>) -> Result<Block> {
     let mut pairs = pair.into_inner();
 
-    let identifier = parse_ident(pairs.next().unwrap());
+    let identifier = parse_ident(pairs.next().unwrap()).into();
 
     let (labels, block_body): (Vec<Pair<Rule>>, Vec<Pair<Rule>>) =
         pairs.partition(|pair| pair.as_rule() != Rule::BlockBody);

--- a/src/structure/block.rs
+++ b/src/structure/block.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename = "$hcl::block")]
 pub struct Block {
     /// The block identifier.
-    pub identifier: String,
+    pub identifier: Identifier,
     /// Zero or more block labels.
     pub labels: Vec<BlockLabel>,
     /// Represents the `Block`'s body.
@@ -28,7 +28,7 @@ impl Block {
     /// Creates a new `Block` from a block identifier, block labels and a block body.
     pub fn new<I, L, B>(identifier: I, labels: L, body: B) -> Block
     where
-        I: Into<String>,
+        I: Into<Identifier>,
         L: IntoIterator,
         L::Item: Into<BlockLabel>,
         B: IntoIterator,
@@ -45,7 +45,7 @@ impl Block {
     /// identifier.
     pub fn builder<I>(identifier: I) -> BlockBuilder
     where
-        I: Into<String>,
+        I: Into<Identifier>,
     {
         BlockBuilder::new(identifier)
     }
@@ -74,14 +74,14 @@ impl From<Block> for Value {
 
 impl<I, B> From<(I, B)> for Block
 where
-    I: Into<String>,
+    I: Into<Identifier>,
     B: Into<Body>,
 {
-    fn from(pair: (I, B)) -> Block {
+    fn from((ident, body): (I, B)) -> Block {
         Block {
-            identifier: pair.0.into(),
+            identifier: ident.into(),
             labels: Vec::new(),
-            body: pair.1.into(),
+            body: body.into(),
         }
     }
 }
@@ -174,7 +174,7 @@ where
 /// ```
 #[derive(Debug)]
 pub struct BlockBuilder {
-    identifier: String,
+    identifier: Identifier,
     labels: Vec<BlockLabel>,
     body: BodyBuilder,
 }
@@ -184,7 +184,7 @@ impl BlockBuilder {
     /// identifier.
     pub fn new<I>(identifier: I) -> BlockBuilder
     where
-        I: Into<String>,
+        I: Into<Identifier>,
     {
         BlockBuilder {
             identifier: identifier.into(),

--- a/src/structure/de.rs
+++ b/src/structure/de.rs
@@ -139,7 +139,7 @@ impl<'de> IntoDeserializer<'de, Error> for Block {
 }
 
 pub struct BlockAccess {
-    identifier: Option<String>,
+    identifier: Option<Identifier>,
     labels: Option<Vec<BlockLabel>>,
     body: Option<Body>,
 }

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -278,7 +278,7 @@ impl IntoNodeMap for Block {
         let node = match labels.next() {
             Some(label) => {
                 let block = Block {
-                    identifier: label.into_inner(),
+                    identifier: Identifier::new(label.into_inner()),
                     labels: labels.collect(),
                     body: self.body,
                 };
@@ -288,7 +288,7 @@ impl IntoNodeMap for Block {
             None => Node::BlockInner(vec![self.body]),
         };
 
-        Map::from_iter(std::iter::once((self.identifier, node)))
+        Map::from_iter(std::iter::once((self.identifier.into_inner(), node)))
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: The `Block` struct's `identifier` field type was changed from `String` to `Identifier`. Furthermore, the trait bound for the block identifier on `Block::new` changed from `Into<String>` to `Into<Identifier>`.