### PR TITLE
fix!: change `Attribute` key field type to `Identifier`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -73,7 +73,7 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute> {
     let mut pairs = pair.into_inner();
 
     Ok(Attribute {
-        key: parse_ident(pairs.next().unwrap()).into_inner(),
+        key: parse_ident(pairs.next().unwrap()),
         expr: parse_expression(pairs.next().unwrap())?,
     })
 }

--- a/src/structure/attribute.rs
+++ b/src/structure/attribute.rs
@@ -1,6 +1,6 @@
 //! Types to represent and build HCL attributes.
 
-use super::{Expression, Value};
+use super::{Expression, Identifier, Value};
 use serde::{Deserialize, Serialize};
 use std::iter;
 
@@ -18,7 +18,7 @@ use std::iter;
 #[serde(rename = "$hcl::attribute")]
 pub struct Attribute {
     /// The HCL attribute's key.
-    pub key: String,
+    pub key: Identifier,
     /// The value expression of the HCL attribute.
     pub expr: Expression,
 }
@@ -28,7 +28,7 @@ impl Attribute {
     /// attribute value that is convertible into an `Expression`.
     pub fn new<K, V>(key: K, expr: V) -> Attribute
     where
-        K: Into<String>,
+        K: Into<Identifier>,
         V: Into<Expression>,
     {
         Attribute {
@@ -56,10 +56,10 @@ impl From<Attribute> for Value {
 
 impl<K, V> From<(K, V)> for Attribute
 where
-    K: Into<String>,
+    K: Into<Identifier>,
     V: Into<Expression>,
 {
-    fn from(pair: (K, V)) -> Attribute {
-        Attribute::new(pair.0.into(), pair.1.into())
+    fn from((key, expr): (K, V)) -> Attribute {
+        Attribute::new(key, expr)
     }
 }

--- a/src/structure/de.rs
+++ b/src/structure/de.rs
@@ -87,7 +87,7 @@ impl<'de> IntoDeserializer<'de, Error> for Attribute {
 }
 
 pub struct AttributeAccess {
-    key: Option<String>,
+    key: Option<Identifier>,
     expr: Option<Expression>,
 }
 

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -362,7 +362,7 @@ impl IntoNodeMap for Body {
         self.into_iter().fold(Map::new(), |mut map, structure| {
             match structure {
                 Structure::Attribute(attr) => {
-                    map.insert(attr.key, Node::Value(attr.expr.into()));
+                    map.insert(attr.key.into_inner(), Node::Value(attr.expr.into()));
                 }
                 Structure::Block(block) => {
                     block

--- a/src/structure/ser/structure.rs
+++ b/src/structure/ser/structure.rs
@@ -1,5 +1,5 @@
 use super::{attribute::*, block::*};
-use crate::{Error, Result, Structure};
+use crate::{Error, Identifier, Result, Structure};
 use serde::ser::{self, Serialize, SerializeMap};
 
 pub struct StructureSerializer;
@@ -56,7 +56,10 @@ impl ser::Serializer for StructureSerializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        Ok(SerializeStructureTupleVariant::new(variant, len))
+        Ok(SerializeStructureTupleVariant::new(
+            Identifier::new(variant)?,
+            len,
+        ))
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
@@ -74,7 +77,10 @@ impl ser::Serializer for StructureSerializer {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        Ok(SerializeStructureStructVariant::new(variant, len))
+        Ok(SerializeStructureStructVariant::new(
+            Identifier::new(variant)?,
+            len,
+        ))
     }
 }
 
@@ -129,9 +135,9 @@ pub struct SerializeStructureTupleVariant {
 }
 
 impl SerializeStructureTupleVariant {
-    pub fn new(variant: &'static str, len: usize) -> Self {
+    pub fn new(key: Identifier, len: usize) -> Self {
         SerializeStructureTupleVariant {
-            inner: SerializeAttributeTupleVariant::new(variant, len),
+            inner: SerializeAttributeTupleVariant::new(key, len),
         }
     }
 }
@@ -204,9 +210,9 @@ pub struct SerializeStructureStructVariant {
 }
 
 impl SerializeStructureStructVariant {
-    pub fn new(variant: &'static str, len: usize) -> Self {
+    pub fn new(key: Identifier, len: usize) -> Self {
         SerializeStructureStructVariant {
-            inner: SerializeAttributeStructVariant::new(variant, len),
+            inner: SerializeAttributeStructVariant::new(key, len),
         }
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: The `Attribute` struct's `key` field type was changed from `String` to `Identifier`. Furthermore, the trait bound for the attribute identifier on `Attribute::new` changed from `Into<String>` to `Into<Identifier>`.

This fixes a long standing issue. `Identifier` was introduced after `Attribute` and the field type wasn't updated yet.