### PR TITLE
chore: move `Identifier` type to crate root

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -210,7 +210,7 @@ pub use self::func::*;
 use crate::parser;
 use crate::structure::*;
 use crate::template::*;
-use crate::{Map, Result, Value};
+use crate::{Identifier, Map, Result, Value};
 use serde::{de, ser};
 
 mod private {

--- a/src/format/impls.rs
+++ b/src/format/impls.rs
@@ -1,5 +1,5 @@
 use super::{private, Format, Formatter};
-use crate::{structure::*, Number, Result, Value};
+use crate::{structure::*, Identifier, Number, Result, Value};
 use std::io::{self, Write};
 
 impl<T> private::Sealed for &T where T: Format {}

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -1,0 +1,190 @@
+use crate::{Error, Result, Variable};
+use serde::{Deserialize, Serialize};
+use std::borrow::{Borrow, Cow};
+use std::fmt;
+use std::ops;
+
+/// Represents an HCL identifier.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(rename = "$hcl::identifier")]
+pub struct Identifier(String);
+
+impl Identifier {
+    /// Create a new `Identifier` after validating that it only contains characters that are
+    /// allowed in HCL identifiers.
+    ///
+    /// See [`Identifier::sanitized`][Identifier::sanitized] for an infallible alternative to this
+    /// function.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use hcl::Identifier;
+    /// assert!(Identifier::new("some_ident").is_ok());
+    /// assert!(Identifier::new("").is_err());
+    /// assert!(Identifier::new("1two3").is_err());
+    /// assert!(Identifier::new("with whitespace").is_err());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// If `ident` contains characters that are not allowed in HCL identifiers or if it is empty an
+    /// error will be returned.
+    pub fn new<T>(ident: T) -> Result<Self>
+    where
+        T: Into<String>,
+    {
+        let ident = ident.into();
+
+        if ident.is_empty() {
+            return Err(Error::InvalidIdentifier(ident));
+        }
+
+        let mut chars = ident.chars();
+        let first = chars.next().unwrap();
+
+        if !is_id_start(first) || !chars.all(is_id_continue) {
+            return Err(Error::InvalidIdentifier(ident));
+        }
+
+        Ok(Identifier(ident))
+    }
+
+    /// Create a new `Identifier` after sanitizing the input if necessary.
+    ///
+    /// If `ident` contains characters that are not allowed in HCL identifiers will be sanitized
+    /// according to the following rules:
+    ///
+    /// - An empty `ident` results in an identifier containing a single underscore.
+    /// - Invalid characters in `ident` will be replaced with underscores.
+    /// - If `ident` starts with a character that is invalid in the first position but would be
+    ///   valid in the rest of an HCL identifier it is prefixed with an underscore.
+    ///
+    /// See [`Identifier::new`][Identifier::new] for a fallible alternative to this function if
+    /// you prefer rejecting invalid identifiers instead of sanitizing them.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use hcl::Identifier;
+    /// assert_eq!(Identifier::sanitized("some_ident").as_str(), "some_ident");
+    /// assert_eq!(Identifier::sanitized("").as_str(), "_");
+    /// assert_eq!(Identifier::sanitized("1two3").as_str(), "_1two3");
+    /// assert_eq!(Identifier::sanitized("with whitespace").as_str(), "with_whitespace");
+    /// ```
+    pub fn sanitized<T>(ident: T) -> Self
+    where
+        T: AsRef<str>,
+    {
+        let input = ident.as_ref();
+
+        if input.is_empty() {
+            return Identifier(String::from('_'));
+        }
+
+        let mut ident = String::with_capacity(input.len());
+
+        for (i, ch) in input.chars().enumerate() {
+            if i == 0 && is_id_start(ch) {
+                ident.push(ch);
+            } else if is_id_continue(ch) {
+                if i == 0 {
+                    ident.push('_');
+                }
+                ident.push(ch);
+            } else {
+                ident.push('_');
+            }
+        }
+
+        Identifier(ident)
+    }
+
+    /// Create a new `Identifier` without checking if it is valid.
+    ///
+    /// It is the caller's responsibility to ensure that the identifier is valid.
+    ///
+    /// For most use cases [`Identifier::new`][Identifier::new] or
+    /// [`Identifier::sanitized`][Identifier::sanitized] should be preferred.
+    ///
+    /// # Safety
+    ///
+    /// This function is not marked as unsafe because it does not cause undefined behaviour.
+    /// However, attempting to serialize an invalid identifier to HCL will produce invalid output.
+    pub fn unchecked<T>(ident: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Identifier(ident.into())
+    }
+
+    /// Consume `self` and return the wrapped `String`.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+
+    /// Return a reference to the wrapped `str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[inline]
+fn is_id_start(ch: char) -> bool {
+    ch == '_' || unicode_ident::is_xid_start(ch)
+}
+
+#[inline]
+fn is_id_continue(ch: char) -> bool {
+    ch == '-' || unicode_ident::is_xid_continue(ch)
+}
+
+impl From<String> for Identifier {
+    fn from(s: String) -> Self {
+        Identifier::sanitized(s)
+    }
+}
+
+impl From<&str> for Identifier {
+    fn from(s: &str) -> Self {
+        Identifier::sanitized(s)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Identifier {
+    fn from(s: Cow<'a, str>) -> Self {
+        Identifier::sanitized(s)
+    }
+}
+
+impl From<Variable> for Identifier {
+    fn from(variable: Variable) -> Self {
+        variable.into_inner()
+    }
+}
+
+impl fmt::Display for Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self)
+    }
+}
+
+impl ops::Deref for Identifier {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for Identifier {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for Identifier {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 mod macros;
 pub mod eval;
 pub mod format;
+mod ident;
 mod number;
 mod parser;
 pub mod ser;
@@ -22,6 +23,7 @@ pub mod value;
 pub use de::{from_body, from_reader, from_slice, from_str};
 #[doc(inline)]
 pub use error::{Error, Result};
+pub use ident::Identifier;
 pub use number::Number;
 pub use parser::parse;
 #[doc(inline)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,7 +3,7 @@ mod template;
 mod tests;
 
 pub use self::template::parse as parse_template;
-use crate::{structure::*, util::unescape, Number, Result};
+use crate::{structure::*, util::unescape, Identifier, Number, Result};
 use pest::{
     iterators::{Pair, Pairs},
     Parser as ParserTrait,

--- a/src/structure/attribute.rs
+++ b/src/structure/attribute.rs
@@ -1,6 +1,7 @@
 //! Types to represent and build HCL attributes.
 
-use super::{Expression, Identifier, Value};
+use super::Expression;
+use crate::{Identifier, Value};
 use serde::{Deserialize, Serialize};
 use std::iter;
 

--- a/src/structure/block.rs
+++ b/src/structure/block.rs
@@ -1,6 +1,7 @@
 //! Types to represent and build HCL blocks.
 
-use super::{Attribute, Body, BodyBuilder, Identifier, IntoNodeMap, Structure, Value};
+use super::{Attribute, Body, BodyBuilder, IntoNodeMap, Structure};
+use crate::{Identifier, Value};
 use serde::{Deserialize, Serialize};
 
 /// Represents an HCL block which consists of a block identifier, zero or more block labels and a

--- a/src/structure/de.rs
+++ b/src/structure/de.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::de::{NewtypeStructDeserializer, OptionDeserializer, VariantName};
-use crate::{Error, Result};
+use crate::{Error, Identifier, Result};
 use serde::de::value::{MapAccessDeserializer, StrDeserializer};
 use serde::de::{self, IntoDeserializer};
 use serde::{forward_to_deserialize_any, Deserializer};

--- a/src/structure/expression.rs
+++ b/src/structure/expression.rs
@@ -1,7 +1,7 @@
 //! Types to represent HCL attribute value expressions.
 
 use super::*;
-use crate::{format, Number};
+use crate::{format, Identifier, Number};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{self, Display, Write};

--- a/src/structure/for_expr.rs
+++ b/src/structure/for_expr.rs
@@ -1,4 +1,5 @@
-use super::{Expression, Identifier};
+use super::Expression;
+use crate::Identifier;
 use serde::{Deserialize, Serialize};
 
 /// A for expression is a construct for constructing a collection by projecting the items from

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -75,196 +75,8 @@ pub use self::{
     traversal::{Traversal, TraversalOperator},
     variable::Variable,
 };
-use crate::{Error, Map, Result, Value};
+use crate::{Map, Value};
 use serde::{Deserialize, Serialize};
-use std::borrow::{Borrow, Cow};
-use std::fmt;
-use std::ops;
-
-/// Represents an HCL identifier.
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
-#[serde(rename = "$hcl::identifier")]
-pub struct Identifier(String);
-
-impl Identifier {
-    /// Create a new `Identifier` after validating that it only contains characters that are
-    /// allowed in HCL identifiers.
-    ///
-    /// See [`Identifier::sanitized`][Identifier::sanitized] for an infallible alternative to this
-    /// function.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use hcl::Identifier;
-    /// assert!(Identifier::new("some_ident").is_ok());
-    /// assert!(Identifier::new("").is_err());
-    /// assert!(Identifier::new("1two3").is_err());
-    /// assert!(Identifier::new("with whitespace").is_err());
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// If `ident` contains characters that are not allowed in HCL identifiers or if it is empty an
-    /// error will be returned.
-    pub fn new<T>(ident: T) -> Result<Self>
-    where
-        T: Into<String>,
-    {
-        let ident = ident.into();
-
-        if ident.is_empty() {
-            return Err(Error::InvalidIdentifier(ident));
-        }
-
-        let mut chars = ident.chars();
-        let first = chars.next().unwrap();
-
-        if !is_id_start(first) || !chars.all(is_id_continue) {
-            return Err(Error::InvalidIdentifier(ident));
-        }
-
-        Ok(Identifier(ident))
-    }
-
-    /// Create a new `Identifier` after sanitizing the input if necessary.
-    ///
-    /// If `ident` contains characters that are not allowed in HCL identifiers will be sanitized
-    /// according to the following rules:
-    ///
-    /// - An empty `ident` results in an identifier containing a single underscore.
-    /// - Invalid characters in `ident` will be replaced with underscores.
-    /// - If `ident` starts with a character that is invalid in the first position but would be
-    ///   valid in the rest of an HCL identifier it is prefixed with an underscore.
-    ///
-    /// See [`Identifier::new`][Identifier::new] for a fallible alternative to this function if
-    /// you prefer rejecting invalid identifiers instead of sanitizing them.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use hcl::Identifier;
-    /// assert_eq!(Identifier::sanitized("some_ident").as_str(), "some_ident");
-    /// assert_eq!(Identifier::sanitized("").as_str(), "_");
-    /// assert_eq!(Identifier::sanitized("1two3").as_str(), "_1two3");
-    /// assert_eq!(Identifier::sanitized("with whitespace").as_str(), "with_whitespace");
-    /// ```
-    pub fn sanitized<T>(ident: T) -> Self
-    where
-        T: AsRef<str>,
-    {
-        let input = ident.as_ref();
-
-        if input.is_empty() {
-            return Identifier(String::from('_'));
-        }
-
-        let mut ident = String::with_capacity(input.len());
-
-        for (i, ch) in input.chars().enumerate() {
-            if i == 0 && is_id_start(ch) {
-                ident.push(ch);
-            } else if is_id_continue(ch) {
-                if i == 0 {
-                    ident.push('_');
-                }
-                ident.push(ch);
-            } else {
-                ident.push('_');
-            }
-        }
-
-        Identifier(ident)
-    }
-
-    /// Create a new `Identifier` without checking if it is valid.
-    ///
-    /// It is the caller's responsibility to ensure that the identifier is valid.
-    ///
-    /// For most use cases [`Identifier::new`][Identifier::new] or
-    /// [`Identifier::sanitized`][Identifier::sanitized] should be preferred.
-    ///
-    /// # Safety
-    ///
-    /// This function is not marked as unsafe because it does not cause undefined behaviour.
-    /// However, attempting to serialize an invalid identifier to HCL will produce invalid output.
-    pub fn unchecked<T>(ident: T) -> Self
-    where
-        T: Into<String>,
-    {
-        Identifier(ident.into())
-    }
-
-    /// Consume `self` and return the wrapped `String`.
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-
-    /// Return a reference to the wrapped `str`.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-#[inline]
-fn is_id_start(ch: char) -> bool {
-    ch == '_' || unicode_ident::is_xid_start(ch)
-}
-
-#[inline]
-fn is_id_continue(ch: char) -> bool {
-    ch == '-' || unicode_ident::is_xid_continue(ch)
-}
-
-impl From<String> for Identifier {
-    fn from(s: String) -> Self {
-        Identifier::sanitized(s)
-    }
-}
-
-impl From<&str> for Identifier {
-    fn from(s: &str) -> Self {
-        Identifier::sanitized(s)
-    }
-}
-
-impl<'a> From<Cow<'a, str>> for Identifier {
-    fn from(s: Cow<'a, str>) -> Self {
-        Identifier::sanitized(s)
-    }
-}
-
-impl From<Variable> for Identifier {
-    fn from(variable: Variable) -> Self {
-        variable.into_inner()
-    }
-}
-
-impl fmt::Display for Identifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self)
-    }
-}
-
-impl ops::Deref for Identifier {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        self.as_str()
-    }
-}
-
-impl AsRef<str> for Identifier {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl Borrow<str> for Identifier {
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
 
 /// Represents an HCL structure.
 ///
@@ -390,7 +202,7 @@ impl IntoNodeMap for Block {
         let node = match labels.next() {
             Some(label) => {
                 let block = Block {
-                    identifier: Identifier::unchecked(label.into_inner()),
+                    identifier: crate::ident::Identifier::unchecked(label.into_inner()),
                     labels: labels.collect(),
                     body: self.body,
                 };
@@ -456,3 +268,13 @@ impl Node {
         }
     }
 }
+
+// Type aliases exposed for backwards compatiblity. Will be removed at one point.
+#[allow(missing_docs)]
+mod deprecated {
+    #[deprecated(since = "0.9.1", note = "use `hcl::Identifier` instead")]
+    pub type Identifier = crate::ident::Identifier;
+}
+
+#[doc(hidden)]
+pub use self::deprecated::*;

--- a/src/structure/ser/tests.rs
+++ b/src/structure/ser/tests.rs
@@ -9,6 +9,7 @@ use super::{
     template_expr::TemplateExprSerializer,
 };
 use crate::structure::*;
+use crate::Identifier;
 use serde::{ser, Serialize};
 use std::fmt::Debug;
 

--- a/src/structure/template_expr.rs
+++ b/src/structure/template_expr.rs
@@ -1,7 +1,6 @@
-use super::Identifier;
 use crate::de::FromStrVisitor;
 use crate::util::{dedent, try_unescape};
-use crate::{Error, Result};
+use crate::{Error, Identifier, Result};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt;

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::Identifier;
 use pretty_assertions::assert_eq;
 use serde_json::json;
 


### PR DESCRIPTION
Also marks `hcl::structure::Identifier` as deprecated. This symbol will be removed in a future release.

For most users this shouldn't be an issue since the `Identifier` type was always available as `hcl::Identifier` and none of the usage examples referenced to it as `hcl::structure::Identifier`.

Relates to #100 