### PR TITLE
chore(format): remove ident validation

### DIFF
--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -250,8 +250,10 @@ impl From<Variable> for Expression {
 
 impl Display for Expression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = format::to_string_unchecked(self);
-        f.write_str(&s)
+        // Formatting an `Expression` as string cannot fail.
+        let formatted =
+            format::to_string(self).expect("an Expression failed to format unexpectedly");
+        f.write_str(&formatted)
     }
 }
 

--- a/src/format/impls.rs
+++ b/src/format/impls.rs
@@ -58,7 +58,7 @@ impl Format for Attribute {
         W: io::Write,
     {
         fmt.begin_attribute()?;
-        fmt.write_ident(&self.key)?;
+        self.key.format(fmt)?;
         fmt.begin_attribute_value()?;
         self.expr.format(fmt)?;
         fmt.end_attribute()?;
@@ -74,7 +74,7 @@ impl Format for Block {
         W: io::Write,
     {
         fmt.begin_block()?;
-        fmt.write_ident(&self.identifier)?;
+        self.identifier.format(fmt)?;
 
         for label in &self.labels {
             fmt.write_all(b" ")?;
@@ -240,7 +240,7 @@ impl Format for Identifier {
     where
         W: io::Write,
     {
-        fmt.write_ident(self)?;
+        fmt.write_string_fragment(self)?;
         Ok(())
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -203,7 +203,8 @@ impl Value {
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = format::to_string_unchecked(self);
-        f.write_str(&s)
+        // Formatting a `Value` as string cannot fail.
+        let formatted = format::to_string(self).expect("a Value failed to format unexpectedly");
+        f.write_str(&formatted)
     }
 }


### PR DESCRIPTION
Identifiers are validated upon creation and are always valid if created via `Identifier::new` or `Identifier::sanitized`. The formatter does not need to validate them again. This also obsoletes the internal strict mode and `to_string_unchecked` function.

Invalid identifiers can only be created via `Identifier::unchecked`, but this would be a user error as stated in the method docs.