### PR TITLE
fix: unclutter crate root exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ assert_eq!(body, expected);
 A simple example to serialize some terraform configuration:
 
 ```rust
-use hcl::{Block, Body, RawExpression};
+use hcl::expr::RawExpression;
+use hcl::{Block, Body};
 
 let body = Body::builder()
     .add_block(
@@ -140,7 +141,7 @@ short example:
 
 ```rust
 use hcl::eval::{Context, Evaluate};
-use hcl::TemplateExpr;
+use hcl::expr::TemplateExpr;
 
 let expr = TemplateExpr::from("Hello ${name}!");
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -21,7 +21,7 @@
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use hcl::eval::{Context, Evaluate};
-//! use hcl::TemplateExpr;
+//! use hcl::expr::TemplateExpr;
 //!
 //! let expr = TemplateExpr::from("Hello ${name}!");
 //!
@@ -73,8 +73,8 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use hcl::eval::Context;
 //! use hcl::Body;
+//! use hcl::eval::Context;
 //!
 //! let input = r#"
 //! operation   = 1 + 1
@@ -110,8 +110,9 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use hcl::Value;
 //! use hcl::eval::{Context, Evaluate, FuncArgs, FuncDef, ParamType};
-//! use hcl::{TemplateExpr, Value};
+//! use hcl::expr::TemplateExpr;
 //!
 //! // A template expression which needs to be evaluated. It needs access
 //! // to the `uppercase` function and `name` variable.
@@ -155,8 +156,8 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use hcl::eval::Context;
 //! use hcl::Body;
+//! use hcl::eval::Context;
 //!
 //! let input = r#"hello_world = "Hello, ${name}!""#;
 //!
@@ -178,8 +179,9 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use hcl::Body;
 //! use hcl::eval::Context;
-//! use hcl::{Body, TemplateExpr};
+//! use hcl::expr::TemplateExpr;
 //!
 //! let expr = TemplateExpr::from("Hello, ${name}!");
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,22 +23,37 @@ pub mod value;
 
 #[doc(inline)]
 pub use de::{from_body, from_reader, from_slice, from_str};
+
 #[doc(inline)]
 pub use error::{Error, Result};
+
 #[doc(inline)]
+pub use expr::{Expression, Object, ObjectKey};
+
+// Deprecated, these re-exports will be removed in a future release.
+#[doc(hidden)]
 pub use expr::{
-    BinaryOp, BinaryOperator, Conditional, Expression, ForExpr, FuncCall, FuncCallBuilder, Heredoc,
-    HeredocStripMode, Object, ObjectKey, Operation, RawExpression, TemplateExpr, Traversal,
-    TraversalOperator, UnaryOp, UnaryOperator, Variable,
+    BinaryOp, BinaryOperator, Conditional, ForExpr, FuncCall, FuncCallBuilder, Heredoc,
+    HeredocStripMode, Operation, RawExpression, TemplateExpr, Traversal, TraversalOperator,
+    UnaryOp, UnaryOperator, Variable,
 };
+
 pub use ident::Identifier;
 pub use number::Number;
 pub use parser::parse;
+
 #[doc(inline)]
 pub use ser::{to_expression, to_string, to_vec, to_writer};
+
 #[doc(inline)]
-pub use structure::{Attribute, Block, BlockBuilder, BlockLabel, Body, BodyBuilder, Structure};
+pub use structure::{Attribute, Block, BlockLabel, Body, Structure};
+
+// Deprecated, these re-exports will be removed in a future release.
+#[doc(hidden)]
+pub use structure::{BlockBuilder, BodyBuilder};
+
 #[doc(inline)]
 pub use template::Template;
+
 #[doc(inline)]
 pub use value::{Map, Value};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,9 +1,7 @@
 /// Construct an `hcl::Body` from HCL blocks and attributes.
 ///
 /// The macro supports a subset of the HCL syntax. If you need more flexibility, use the
-/// [`BlockBuilder`][BlockBuilder] instead.
-///
-/// [BlockBuilder]: ./struct.BlockBuilder.html
+/// [`BlockBuilder`][crate::structure::BlockBuilder] instead.
 ///
 /// ## Supported Syntax
 ///
@@ -28,19 +26,10 @@
 /// The `body!` macro is composed out of different other macros that can be used on their own to
 /// construct HCL data structures:
 ///
-/// - [`attribute!`][`crate::attribute!`]: constructs an [`Attribute`][Attribute]
-/// - [`block!`][`crate::block!`]: constructs a [`Block`][Block]
-/// - [`block_label!`][`crate::block_label!`]: constructs a [`BlockLabel`][BlockLabel]
-/// - [`expression!`][`crate::expression!`]: constructs an [`Expression`][Expression]
-/// - [`object_key!`][`crate::object_key!`]: constructs an [`ObjectKey`][ObjectKey]
-/// - [`structure!`][`crate::structure!`]: constructs a [`Structure`][Structure]
-///
-/// [Attribute]: ./struct.Attribute.html
-/// [Block]: ./struct.Block.html
-/// [BlockLabel]: ./enum.BlockLabel.html
-/// [Expression]: ./enum.Expression.html
-/// [ObjectKey]: ./enum.ObjectKey.html
-/// [Structure]: ./enum.Structure.html
+/// - [`attribute!`][`crate::attribute!`]: constructs an [`Attribute`][crate::structure::Attribute]
+/// - [`block!`][`crate::block!`]: constructs a [`Block`][crate::structure::Block]
+/// - [`expression!`][`crate::expression!`]: constructs an [`Expression`][crate::expr::Expression]
+/// - [`structure!`][`crate::structure!`]: constructs a [`Structure`][crate::structure::Structure]
 ///
 /// ## Examples
 ///
@@ -348,26 +337,8 @@ macro_rules! block_internal {
     };
 }
 
-/// Construct an `hcl::BlockLabel`.
-///
-/// For supported syntax see the [`body!`] macro documentation.
-///
-/// ## Examples
-///
-/// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use hcl::{BlockLabel, Identifier};
-///
-/// assert_eq!(hcl::block_label!(some_identifier), BlockLabel::from(Identifier::new("some_identifier")?));
-/// assert_eq!(hcl::block_label!("some string"), BlockLabel::from("some string"));
-///
-/// let label = "some expression";
-///
-/// assert_eq!(hcl::block_label!((label)), BlockLabel::from("some expression"));
-/// #    Ok(())
-/// # }
-/// ```
 #[macro_export]
+#[doc(hidden)]
 macro_rules! block_label {
     ($ident:ident) => {
         $crate::structure::BlockLabel::Identifier($crate::Identifier::unchecked(std::stringify!(
@@ -384,26 +355,8 @@ macro_rules! block_label {
     };
 }
 
-/// Construct an `hcl::ObjectKey`.
-///
-/// For supported syntax see the [`body!`] macro documentation.
-///
-/// ## Examples
-///
-/// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use hcl::{Identifier, ObjectKey};
-///
-/// assert_eq!(hcl::object_key!(some_identifier), ObjectKey::from(Identifier::new("some_identifier")?));
-/// assert_eq!(hcl::object_key!("some string"), ObjectKey::from("some string"));
-///
-/// let key = "some expression";
-///
-/// assert_eq!(hcl::object_key!((key)), ObjectKey::from("some expression"));
-/// #     Ok(())
-/// # }
-/// ```
 #[macro_export]
+#[doc(hidden)]
 macro_rules! object_key {
     ($ident:ident) => {
         $crate::expr::ObjectKey::Identifier($crate::Identifier::unchecked(std::stringify!($ident)))

--- a/src/number.rs
+++ b/src/number.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
-/// Represents a HCL number.
+/// Represents an HCL number.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd)]
 pub struct Number {
     n: N,

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,8 +1,8 @@
 //! Types to represent the HCL template sub-language.
 //!
 //! When parsing an HCL document, template expressions are emitted as
-//! [`TemplateExpr`][`crate::structure::TemplateExpr`] (as the `TemplateExpr` variant of the
-//! [`Expression`][`crate::structure::Expression`] enum) which contains the raw unparsed template
+//! [`TemplateExpr`][crate::expr::TemplateExpr] (as the `TemplateExpr` variant of the
+//! [`Expression`][crate::expr::Expression] enum) which contains the raw unparsed template
 //! expressions.
 //!
 //! These template expressions can be further parsed into a [`Template`] which is composed of
@@ -43,7 +43,8 @@
 //! # use std::error::Error;
 //! #
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! use hcl::{Identifier, Variable};
+//! use hcl::Identifier;
+//! use hcl::expr::Variable;
 //! use hcl::template::{ForDirective, StripMode, Template};
 //! use std::str::FromStr;
 //!


### PR DESCRIPTION
Hide some exports at the crate root from the docs. It got pretty crowded in there and it's really hard to see which types are the most relevant. Re-exporting every single type from the `expr` and `structure` module was a mistake. Only the most useful ones should be re-exported.

Furthermore the `block_label!` and `object_key!` macros are hidden now as well since they do not add much value on their own. They're more meant for internal usage to build higher level macros like `block!` and `expression!`.

This is not a breaking change. The exports are still usable but hidden from the docs with the intention to remove them entirely in a future release.