### PR TITLE
feat(value): add `ValueSerializer` and `to_value`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,4 +56,4 @@ pub use structure::{BlockBuilder, BodyBuilder};
 pub use template::Template;
 
 #[doc(inline)]
-pub use value::{Map, Value};
+pub use value::{to_value, Map, Value};

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,10 +1,12 @@
-use super::Value;
-use serde::ser::{Serialize, Serializer};
+use super::{to_value, Map, Value};
+use crate::{ser::StringSerializer, Error, Number, Result};
+use serde::ser;
+use std::fmt::Display;
 
-impl Serialize for Value {
+impl ser::Serialize for Value {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         match *self {
             Value::Null => serializer.serialize_unit(),
@@ -14,5 +16,291 @@ impl Serialize for Value {
             Value::Array(ref v) => v.serialize(serializer),
             Value::Object(ref v) => v.serialize(serializer),
         }
+    }
+}
+
+pub struct ValueSerializer;
+
+impl ser::Serializer for ValueSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    type SerializeSeq = SerializeSeq;
+    type SerializeTuple = SerializeSeq;
+    type SerializeTupleStruct = SerializeSeq;
+    type SerializeTupleVariant = SerializeTupleVariant;
+    type SerializeMap = SerializeMap;
+    type SerializeStruct = SerializeMap;
+    type SerializeStructVariant = SerializeStructVariant;
+
+    serialize_self! { some newtype_struct }
+    forward_to_serialize_seq! { tuple tuple_struct }
+
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok> {
+        Ok(Value::Bool(value))
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok> {
+        self.serialize_u64(value as u64)
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok> {
+        self.serialize_u64(value as u64)
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok> {
+        self.serialize_u64(value as u64)
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<Self::Ok> {
+        self.serialize_f64(value as f64)
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<Self::Ok> {
+        Ok(Number::from_f64(value).map_or(Value::Null, Value::Number))
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok> {
+        Ok(Value::String(value.to_string()))
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok> {
+        Ok(Value::String(value.to_owned()))
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok> {
+        let vec = value.iter().map(|&b| Value::Number(b.into())).collect();
+        Ok(Value::Array(vec))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok> {
+        Ok(Value::Null)
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let mut object = Map::with_capacity(1);
+        object.insert(variant.to_owned(), to_value(value)?);
+        Ok(Value::Object(object))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok> {
+        self.serialize_unit()
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(SerializeSeq {
+            vec: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Ok(SerializeTupleVariant {
+            name: variant.to_owned(),
+            vec: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
+        Ok(SerializeMap {
+            map: Map::with_capacity(len.unwrap_or(0)),
+            next_key: None,
+        })
+    }
+
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Ok(SerializeStructVariant {
+            name: variant.to_owned(),
+            map: Map::with_capacity(len),
+        })
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: ?Sized + Display,
+    {
+        Ok(Value::String(value.to_string()))
+    }
+}
+
+pub struct SerializeSeq {
+    vec: Vec<Value>,
+}
+
+impl ser::SerializeSeq for SerializeSeq {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.vec.push(to_value(value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(Value::Array(self.vec))
+    }
+}
+
+impl ser::SerializeTuple for SerializeSeq {
+    impl_forward_to_serialize_seq!(serialize_element, Value);
+}
+
+impl ser::SerializeTupleStruct for SerializeSeq {
+    impl_forward_to_serialize_seq!(serialize_field, Value);
+}
+
+pub struct SerializeTupleVariant {
+    name: String,
+    vec: Vec<Value>,
+}
+
+impl ser::SerializeTupleVariant for SerializeTupleVariant {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.vec.push(to_value(value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        let mut object = Map::with_capacity(1);
+        object.insert(self.name, self.vec.into());
+        Ok(Value::Object(object))
+    }
+}
+
+pub struct SerializeMap {
+    map: Map<String, Value>,
+    next_key: Option<String>,
+}
+
+impl ser::SerializeMap for SerializeMap {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.next_key = Some(key.serialize(StringSerializer)?);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        let key = self.next_key.take();
+        let key = key.expect("serialize_value called before serialize_key");
+        self.map.insert(key, to_value(value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        Ok(Value::Object(self.map))
+    }
+}
+
+impl ser::SerializeStruct for SerializeMap {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        ser::SerializeMap::serialize_entry(self, key, value)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        ser::SerializeMap::end(self)
+    }
+}
+
+pub struct SerializeStructVariant {
+    name: String,
+    map: Map<String, Value>,
+}
+
+impl ser::SerializeStructVariant for SerializeStructVariant {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + ser::Serialize,
+    {
+        self.map.insert(key.to_owned(), to_value(value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        let mut object = Map::with_capacity(1);
+        object.insert(self.name, self.map.into());
+        Ok(Value::Object(object))
     }
 }


### PR DESCRIPTION
This allows to convert arbitrary types implementing `Serialize` into a `Value`. It will be used by the `value!` macro that will be added in a separate change.