### PR TITLE
feat(macros): add `value!` macro

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -48,9 +48,8 @@ impl Deserializer {
 ///
 /// ```
 /// use serde_json::{json, Value};
-/// # use std::error::Error;
-/// #
-/// # fn main() -> Result<(), Box<dyn Error>> {
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let input = r#"
 ///     some_attr = {
 ///       foo = [1, 2]
@@ -99,10 +98,9 @@ where
 /// # Example
 ///
 /// ```
-/// use serde_json::{json, Value};
-/// # use std::error::Error;
-/// #
-/// # fn main() -> Result<(), Box<dyn Error>> {
+/// use hcl::Value;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let input = r#"
 ///     some_attr = {
 ///       foo = [1, 2]
@@ -114,14 +112,14 @@ where
 ///     }
 /// "#;
 ///
-/// let expected = json!({
-///     "some_attr": {
-///         "foo": [1, 2],
-///         "bar": true
-///     },
-///     "some_block": {
-///         "some_block_label": {
-///             "attr": "value"
+/// let expected = hcl::value!({
+///     some_attr = {
+///         foo = [1, 2]
+///         bar = true
+///     }
+///     some_block = {
+///         some_block_label = {
+///             attr = "value"
 ///         }
 ///     }
 /// });

--- a/src/ser/tests.rs
+++ b/src/ser/tests.rs
@@ -5,9 +5,8 @@ use crate::expr::{
     TraversalOperator, Variable,
 };
 use crate::structure::{Attribute, Block, Body};
-use crate::Identifier;
+use crate::{value, Identifier};
 use pretty_assertions::assert_eq;
-use serde_json::json;
 
 #[track_caller]
 fn expect_str<T: Serialize>(value: T, expected: &str) {
@@ -134,12 +133,12 @@ qux {
 
 #[test]
 fn serialize_object() {
-    let value = json!({
-        "foo": [1, 2, 3],
-        "bar": "baz",
-        "qux": {
-            "foo": "bar",
-            "baz": "qux"
+    let value = value!({
+        foo = [1, 2, 3]
+        bar = "baz"
+        qux = {
+            "foo" = "bar"
+            "baz" = "qux"
         }
     });
 
@@ -160,17 +159,17 @@ qux = {
 
 #[test]
 fn serialize_array() {
-    let value = json!([
+    let value = value!([
         {
-            "foo": [1, 2, 3],
+            foo = [1, 2, 3]
         },
         {
-            "bar": "baz",
+            bar = "baz"
         },
         {
-            "qux": {
-                "foo": "bar",
-                "baz": "qux"
+            qux = {
+                "foo" = "bar"
+                "baz" = "qux"
             }
         }
     ]);
@@ -356,7 +355,7 @@ HEREDOC
 fn serialize_errors() {
     assert!(to_string(&true).is_err());
     assert!(to_string("foo").is_err());
-    assert!(to_string(&json!({"\"": "invalid attribute name"})).is_err())
+    assert!(to_string(&value!({ "\"" = "invalid attribute name" })).is_err())
 }
 
 #[test]

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -1,8 +1,7 @@
 use super::{Block, Body};
 use crate::expr::{Heredoc, HeredocStripMode, RawExpression, TemplateExpr};
-use crate::{Identifier, Value};
+use crate::{value, Identifier, Value};
 use pretty_assertions::assert_eq;
-use serde_json::json;
 
 #[test]
 fn body_into_value() {
@@ -41,26 +40,24 @@ fn body_into_value() {
         ))
         .build();
 
-    let value = json!({
-        "foo": "baz",
-        "bar": {
-            "baz": [
+    let expected = value!({
+        foo = "baz"
+        bar = {
+            baz = [
                 {
-                    "foo": "bar"
+                    foo = "bar"
                 },
                 {
-                    "bar": "baz",
-                    "baz": "${var.foo}"
+                    bar = "baz"
+                    baz = "${var.foo}"
                 }
-            ],
-            "qux": {
-                "foo": 1
-            },
-        },
-        "heredoc": "foo bar ${baz}\\backslash"
+            ]
+            qux = {
+                foo = 1
+            }
+        }
+        heredoc = "foo bar ${baz}\\backslash"
     });
-
-    let expected: Value = serde_json::from_value(value).unwrap();
 
     assert_eq!(Value::from(body), expected);
 }


### PR DESCRIPTION
This can be used in places where `serde_json::json!` was used previously. It has the same syntax as the `expression!` macro with some restrictions around raw expressions.