### PR TITLE
fix!(eval): correctly handle interpolation unwrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ details and examples for expression and template evaluation, but here's a very
 short example:
 
 ```rust
+use hcl::Value;
 use hcl::eval::{Context, Evaluate};
 use hcl::expr::TemplateExpr;
 
@@ -160,7 +161,7 @@ let expr = TemplateExpr::from("Hello ${name}!");
 let mut ctx = Context::new();
 ctx.declare_var("name", "World");
 
-assert_eq!(expr.evaluate(&ctx).unwrap(), "Hello World!");
+assert_eq!(expr.evaluate(&ctx).unwrap(), Value::from("Hello World!"));
 ```
 
 ## Macros

--- a/src/eval/expr.rs
+++ b/src/eval/expr.rs
@@ -8,10 +8,15 @@ pub(super) fn evaluate_bool(expr: &Expression, ctx: &Context) -> EvalResult<bool
     }
 }
 
-pub(super) fn evaluate_string(expr: &Expression, ctx: &Context) -> EvalResult<String> {
+// It's not formally defined, but the go HCL implementation allows object key expressions to
+// evaluate to either a string, boolean value or number and will then convert all of these to
+// string. Any other value shall produce an error.
+pub(super) fn evaluate_object_key(expr: &Expression, ctx: &Context) -> EvalResult<String> {
     match expr.evaluate(ctx)? {
         Value::String(value) => Ok(value),
-        other => Err(ctx.error(Error::unexpected(other, "a string"))),
+        Value::Bool(value) => Ok(value.to_string()),
+        Value::Number(value) => Ok(value.to_string()),
+        other => Err(ctx.error(Error::unexpected(other, "a string, boolean or number"))),
     }
 }
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -20,6 +20,7 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use hcl::Value;
 //! use hcl::eval::{Context, Evaluate};
 //! use hcl::expr::TemplateExpr;
 //!
@@ -28,7 +29,7 @@
 //! let mut ctx = Context::new();
 //! ctx.declare_var("name", "World");
 //!
-//! assert_eq!(expr.evaluate(&ctx)?, "Hello World!");
+//! assert_eq!(expr.evaluate(&ctx)?, Value::from("Hello World!"));
 //! #   Ok(())
 //! # }
 //! ```
@@ -137,7 +138,7 @@
 //! ctx.declare_func("uppercase", uppercase_func);
 //!
 //! // Evaluate the expression.
-//! assert_eq!(expr.evaluate(&ctx)?, "Hello WORLD!");
+//! assert_eq!(expr.evaluate(&ctx)?, Value::from("Hello WORLD!"));
 //! #   Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
BREAKING CHANGE: the `Evaluate` implementation of `TemplateExpr` returns a `Value` instead of a `String` now to support interpolation unwrapping.

This implements template interpolation unwrapping as described in https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#template-interpolation-unwrapping

It also fixes a bug in the object key evaluation logic. See the comment on `evaluate_object_key` (renamed from `evaluate_string`).