### PR TITLE
feat(format): add `prefer_ident_keys` to `FormatterBuilder`

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -77,6 +77,7 @@ struct FormatConfig<'a> {
     dense: bool,
     compact_arrays: bool,
     compact_objects: bool,
+    prefer_ident_keys: bool,
 }
 
 impl<'a> Default for FormatConfig<'a> {
@@ -86,6 +87,7 @@ impl<'a> Default for FormatConfig<'a> {
             dense: false,
             compact_arrays: false,
             compact_objects: false,
+            prefer_ident_keys: false,
         }
     }
 }
@@ -246,6 +248,34 @@ impl<'a, W> FormatterBuilder<'a, W> {
     /// ```
     pub fn compact_objects(mut self, yes: bool) -> Self {
         self.config.compact_objects = yes;
+        self
+    }
+
+    /// Controls the object key quoting.
+    ///
+    /// By default, object keys are formatted as quoted strings (unless they are of variant
+    /// [`ObjectKey::Identifier`][ident-variant]).
+    ///
+    /// ```hcl
+    /// object = {
+    ///   "foo" = 1
+    ///   "bar baz" = 2
+    /// }
+    /// ```
+    ///
+    /// When identifier keys are preferred, object keys that are also valid HCL identifiers are
+    /// not quoted:
+    ///
+    /// ```hcl
+    /// object = {
+    ///   foo = 1
+    ///   "bar baz" = 2
+    /// }
+    /// ```
+    ///
+    /// [ident-variant]: crate::expr::ObjectKey::Identifier
+    pub fn prefer_ident_keys(mut self, yes: bool) -> Self {
+        self.config.prefer_ident_keys = yes;
         self
     }
 

--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -131,3 +131,27 @@ fn issue_131() {
 
     expect_format(value!({ a = "${\"b\"}" }), "{\n  \"a\" = \"${\"b\"}\"\n}");
 }
+
+#[test]
+fn prefer_ident_keys() {
+    let attr = Attribute::new(
+        "object",
+        expression!({
+            "foo" = 1
+            bar = 2
+            "baz qux" = 3
+        }),
+    );
+
+    expect_formatb(
+        |b| b.prefer_ident_keys(false),
+        &attr,
+        "object = {\n  \"foo\" = 1\n  bar = 2\n  \"baz qux\" = 3\n}\n",
+    );
+
+    expect_formatb(
+        |b| b.prefer_ident_keys(true),
+        &attr,
+        "object = {\n  foo = 1\n  bar = 2\n  \"baz qux\" = 3\n}\n",
+    );
+}

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -1,4 +1,5 @@
 use crate::expr::Variable;
+use crate::util::{is_id_continue, is_id_start, is_ident};
 use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::borrow::{Borrow, Cow};
@@ -37,14 +38,7 @@ impl Identifier {
     {
         let ident = ident.into();
 
-        if ident.is_empty() {
-            return Err(Error::InvalidIdentifier(ident));
-        }
-
-        let mut chars = ident.chars();
-        let first = chars.next().unwrap();
-
-        if !is_id_start(first) || !chars.all(is_id_continue) {
+        if !is_ident(&ident) {
             return Err(Error::InvalidIdentifier(ident));
         }
 
@@ -128,16 +122,6 @@ impl Identifier {
     pub fn as_str(&self) -> &str {
         &self.0
     }
-}
-
-#[inline]
-fn is_id_start(ch: char) -> bool {
-    ch == '_' || unicode_ident::is_xid_start(ch)
-}
-
-#[inline]
-fn is_id_continue(ch: char) -> bool {
-    ch == '-' || unicode_ident::is_xid_continue(ch)
 }
 
 impl From<String> for Identifier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
     clippy::option_option,
     clippy::return_self_not_must_use,
     clippy::should_implement_trait,
+    clippy::struct_excessive_bools,
     clippy::unnecessary_wraps,
     clippy::wildcard_imports
 )]

--- a/src/util.rs
+++ b/src/util.rs
@@ -132,6 +132,7 @@ pub fn try_unescape(s: &str) -> Cow<str> {
 ///
 /// This function only looks for start markers and does not check if the template is actually
 /// valid.
+#[inline]
 pub fn is_templated(s: &str) -> bool {
     if s.len() < 3 {
         return false;
@@ -160,6 +161,31 @@ pub fn is_templated(s: &str) -> bool {
     }
 
     false
+}
+
+/// Determines if `ch` is a valid HCL identifier start character.
+#[inline]
+pub fn is_id_start(ch: char) -> bool {
+    ch == '_' || unicode_ident::is_xid_start(ch)
+}
+
+/// Determines if `ch` is a valid HCL identifier continue character.
+#[inline]
+pub fn is_id_continue(ch: char) -> bool {
+    ch == '-' || unicode_ident::is_xid_continue(ch)
+}
+
+/// Determines if `s` represents a valid HCL identifier.
+#[inline]
+pub fn is_ident(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+
+    let mut chars = s.chars();
+    let first = chars.next().unwrap();
+
+    is_id_start(first) && chars.all(is_id_continue)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This allows to configure the formatting behaviour for object key strings that are valid HCL identifiers as well. This is not enabled by default.

Closes #132