### PR TITLE
feat(format): allow formatting to `String` and `Vec<u8>` directly

### DIFF
--- a/src/format/tests.rs
+++ b/src/format/tests.rs
@@ -16,10 +16,8 @@ where
     T: Format,
     F: FnOnce(FormatterBuilder<'a>) -> FormatterBuilder<'a>,
 {
-    let mut buf = Vec::with_capacity(128);
-    let mut fmt = f(Formatter::builder()).build(&mut buf);
-    value.format(&mut fmt).unwrap();
-    let formatted = std::str::from_utf8(&buf).unwrap();
+    let mut fmt = f(Formatter::builder()).build_vec();
+    let formatted = value.format_string(&mut fmt).unwrap();
     assert_eq!(formatted, expected);
 }
 


### PR DESCRIPTION
This makes using a custom `Formatter` more convenient. The new `build_vec` method of `FormatterBuilder` returns a `Formatter` with an internal `Vec<u8>` buffer which can be used in combination with `Format::format_string` and `Format::format_vec`.

The `Serializer` also received the `serialize_string` and `serialize_vec` methods for writers implementing `AsMut<Vec<u8>>`.

This change also lowers the number of unsafe usages in this crate from 3 to 1.