### PR TITLE
fix(eval): implement correct template literal stripping

### DIFF
--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -337,7 +337,10 @@ fn eval_template() {
         Let's ${~ what ~} :
         %{ for item in items ~}
         - ${item}
+
         %{~ endfor ~}
+
+        Yay!
 
     "#};
 
@@ -346,8 +349,10 @@ fn eval_template() {
         - foo
         - bar
         - baz
-    "#}
-    .trim_end();
+
+        Yay!
+
+    "#};
 
     let mut ctx = Context::new();
     ctx.declare_var("what", " render a list");


### PR DESCRIPTION
This fixes two issues:

- Whitespace should only be stripped from literals up until (and including) the next line break. Previously, all preceding/following line breaks were removed.
- The `for` directive's strip mode must be applied to all templates that are looped over, not just the first and last collection item.