### PR TITLE
feat(perf)!: optionally inline identifier strings on the stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,15 @@ name = "specsuite"
 path = "specsuite/main.rs"
 harness = false
 
+[features]
+default = []
+perf = ["dep:kstring"]
+
 [dependencies]
 pest = "2.5.2"
 pest_derive = "2.5.2"
 itoa = "1.0.5"
+kstring = { version = "2.0.0", features = ["max_inline", "serde"], optional = true }
 ryu = "1.0.12"
 unicode-ident = "1.0.6"
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ A rust library for interacting with the Hashicorp Configuration Language (HCL).
   implement `serde::Deserialize` or `serde::Serialize`
 - Evaluation of the HCL expression and template sub-languages
 
+## Cargo features
+
+- `perf`: enables parser performance optimizations such as inlining of small
+  strings on the stack. This feature is disabled by default. Enabling it will
+  pull in `kstring` as a dependency.
+
 ## Deserialization examples
 
 Deserialize arbitrary HCL according to the [HCL JSON

--- a/src/expr/variable.rs
+++ b/src/expr/variable.rs
@@ -1,4 +1,4 @@
-use crate::{Identifier, Result};
+use crate::{Identifier, InternalString, Result};
 use serde::Deserialize;
 use std::ops::Deref;
 
@@ -25,7 +25,7 @@ impl Variable {
     /// error will be returned.
     pub fn new<T>(ident: T) -> Result<Self>
     where
-        T: Into<String>,
+        T: Into<InternalString>,
     {
         Identifier::new(ident).map(Variable)
     }
@@ -53,7 +53,7 @@ impl Variable {
     /// output.
     pub fn unchecked<T>(ident: T) -> Self
     where
-        T: Into<String>,
+        T: Into<InternalString>,
     {
         Variable(Identifier::unchecked(ident))
     }

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -1,6 +1,6 @@
 use crate::expr::Variable;
 use crate::util::{is_id_continue, is_id_start, is_ident};
-use crate::{Error, Result};
+use crate::{Error, InternalString, Result};
 use serde::{Deserialize, Serialize};
 use std::borrow::{Borrow, Cow};
 use std::fmt;
@@ -9,7 +9,7 @@ use std::ops;
 /// Represents an HCL identifier.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(transparent)]
-pub struct Identifier(String);
+pub struct Identifier(InternalString);
 
 impl Identifier {
     /// Create a new `Identifier` after validating that it only contains characters that are
@@ -34,12 +34,12 @@ impl Identifier {
     /// error will be returned.
     pub fn new<T>(ident: T) -> Result<Self>
     where
-        T: Into<String>,
+        T: Into<InternalString>,
     {
         let ident = ident.into();
 
         if !is_ident(&ident) {
-            return Err(Error::InvalidIdentifier(ident));
+            return Err(Error::InvalidIdentifier(ident.to_string()));
         }
 
         Ok(Identifier(ident))
@@ -74,7 +74,7 @@ impl Identifier {
         let input = ident.as_ref();
 
         if input.is_empty() {
-            return Identifier(String::from('_'));
+            return Identifier(InternalString::from("_"));
         }
 
         let mut ident = String::with_capacity(input.len());
@@ -92,7 +92,7 @@ impl Identifier {
             }
         }
 
-        Identifier(ident)
+        Identifier(InternalString::from(ident))
     }
 
     /// Create a new `Identifier` without checking if it is valid.
@@ -108,19 +108,19 @@ impl Identifier {
     /// However, attempting to serialize an invalid identifier to HCL will produce invalid output.
     pub fn unchecked<T>(ident: T) -> Self
     where
-        T: Into<String>,
+        T: Into<InternalString>,
     {
         Identifier(ident.into())
     }
 
     /// Consume `self` and return the wrapped `String`.
     pub fn into_inner(self) -> String {
-        self.0
+        self.0.into()
     }
 
     /// Return a reference to the wrapped `str`.
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 

--- a/src/internal_string.rs
+++ b/src/internal_string.rs
@@ -1,0 +1,161 @@
+use std::borrow::{Borrow, Cow};
+use std::fmt;
+use std::ops::Deref;
+
+#[cfg(feature = "perf")]
+type Inner = kstring::KString;
+#[cfg(not(feature = "perf"))]
+type Inner = String;
+
+/// An opaque string storage which inlines small strings on the stack if the `perf` feature is
+/// enabled.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InternalString(Inner);
+
+impl InternalString {
+    /// Create a new empty `InternalString`.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        #[cfg(feature = "perf")]
+        let inner = kstring::KString::EMPTY;
+        #[cfg(not(feature = "perf"))]
+        let inner = String::new();
+
+        InternalString(inner)
+    }
+
+    /// Returns a reference to the underlying string.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Default for InternalString {
+    fn default() -> Self {
+        InternalString::new()
+    }
+}
+
+impl Deref for InternalString {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for InternalString {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for InternalString {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<&str> for InternalString {
+    #[inline]
+    fn from(s: &str) -> Self {
+        #[cfg(feature = "perf")]
+        let inner = kstring::KString::from_ref(s);
+        #[cfg(not(feature = "perf"))]
+        let inner = String::from(s);
+
+        InternalString(inner)
+    }
+}
+
+impl From<String> for InternalString {
+    #[inline]
+    fn from(s: String) -> Self {
+        #[cfg(feature = "perf")]
+        let inner = kstring::KString::from_string(s);
+        #[cfg(not(feature = "perf"))]
+        let inner = s;
+
+        InternalString(inner)
+    }
+}
+
+impl From<&String> for InternalString {
+    #[inline]
+    fn from(s: &String) -> Self {
+        InternalString(s.into())
+    }
+}
+
+impl From<&InternalString> for InternalString {
+    #[inline]
+    fn from(s: &InternalString) -> Self {
+        s.clone()
+    }
+}
+
+impl From<Box<str>> for InternalString {
+    #[inline]
+    fn from(s: Box<str>) -> Self {
+        InternalString(s.into())
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for InternalString {
+    #[inline]
+    fn from(s: Cow<'a, str>) -> Self {
+        match s {
+            Cow::Borrowed(borrowed) => borrowed.into(),
+            Cow::Owned(owned) => owned.into(),
+        }
+    }
+}
+
+impl From<InternalString> for String {
+    #[inline]
+    fn from(is: InternalString) -> Self {
+        #[cfg(feature = "perf")]
+        let string = is.0.to_string();
+        #[cfg(not(feature = "perf"))]
+        let string = is.0;
+
+        string
+    }
+}
+
+impl fmt::Debug for InternalString {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl fmt::Display for InternalString {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+impl serde::Serialize for InternalString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for InternalString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Inner::deserialize(deserializer).map(InternalString)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod eval;
 pub mod expr;
 pub mod format;
 mod ident;
+mod internal_string;
 mod number;
 mod parser;
 pub mod ser;
@@ -39,6 +40,9 @@ pub mod template;
 mod tests;
 mod util;
 pub mod value;
+
+#[doc(inline)]
+pub use internal_string::InternalString;
 
 #[doc(inline)]
 pub use de::{from_body, from_reader, from_slice, from_str};


### PR DESCRIPTION
BREAKING CHANGE: The trait bounds on `Identifier::{new,unchecked}` and `Variable::{new,unchecked}` were changed from `Into<String>` to `Into<InternalString>`. This has no impact on common use cases involving std types but may break code using custom types.

Most identifiers are relatively short and can be inlined on the stack.

The `perf` feature improves parser performance by around 5%.

I could have added this to `Identifier` directly instead of creating a separate type. However, internal strings will be used in the new parser implementation to make tracking whitespace and comments in HCL documents more performant, so I'm already designing this as a reusable type not limited to identifiers.