### PR TITLE
fix(format): Do not unescape heredoc strings

### DIFF
--- a/crates/hcl-rs/src/expr/template_expr.rs
+++ b/crates/hcl-rs/src/expr/template_expr.rs
@@ -51,7 +51,10 @@ impl From<Heredoc> for TemplateExpr {
 
 impl fmt::Display for TemplateExpr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&try_unescape(self.as_str()))
+        match self {
+            TemplateExpr::QuotedString(_) => f.write_str(&try_unescape(self.as_str())),
+            TemplateExpr::Heredoc(_) => f.write_str(self.as_str()),
+        }
     }
 }
 

--- a/crates/specsuite/tests/expressions/heredoc-noescape.hcl
+++ b/crates/specsuite/tests/expressions/heredoc-noescape.hcl
@@ -1,0 +1,11 @@
+// The mixing of QuotedString in the test with the Heredoc output in the results
+// is important to this test.  It ensures proper escaping for both code paths
+unescaped_regex = {
+    contents = <<-EOT
+        www\\.example\\.com
+    EOT
+}
+
+escaped_regex = {
+    contents = "www\\\\.example\\\\.com\n"
+}

--- a/crates/specsuite/tests/expressions/heredoc-noescape.t
+++ b/crates/specsuite/tests/expressions/heredoc-noescape.t
@@ -1,0 +1,13 @@
+// The mixing of QuotedString in the test with the Heredoc output in the results
+// is important to this test. It ensures proper escaping for both code paths
+result = {
+    unescaped_regex = {
+        contents = "www\\\\.example\\\\.com\n"
+    }
+
+    escaped_regex = {
+        contents = <<-EOT
+            www\\.example\\.com
+            EOT
+    }
+}


### PR DESCRIPTION
[Current logic](https://github.com/martinohmann/hcl-rs/blob/5cf6f967adc18388b9c2d149d515ee603509bc36/crates/hcl-rs/src/expr/template_expr.rs#L52) has `TemplateExpr` doing a `try_unescape` with both a `QuotedString` and `Heredoc` inside  `fmt::Display` This causes side effects when legitimate and valid \\ characters are contained within a heredoc

This shows itself with bash scripts, or regular expressions which need escaping. The use case which stumbled upon this was regex in TOML.
```
let content = r###"
config = {
  content = <<-EOT
    www\\.example\\.com
    EOT
}
"###;
println!("{}", hcl::to_string(hcl::from_str(&content)?)?);
```
The output `content` is the string `www\.example\.com` which is incorrect, this PR corrects that.   

As a side note, use of `hcl::eval::from_str` does not exhibit this problem, which is used by the specsuite for loading it's HCL tests, making it incapable of testing this error directly.   Since the `t` file is loaded using `hcl::from_str` which is affected, a test can be done by using a QuotedString for the test, and a Heredoc for the results and vice versa, which is what was done. 