### PR TITLE
fix!: make fields without invariants public

### DIFF
--- a/crates/hcl-edit/src/encode/expr.rs
+++ b/crates/hcl-edit/src/encode/expr.rs
@@ -123,28 +123,26 @@ impl Encode for ObjectValue {
 
 impl Encode for ForExpr {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        if let Some(key_expr) = self.key_expr() {
+        if let Some(key_expr) = &self.key_expr {
             // object expr
             buf.write_char('{')?;
-            self.intro().encode_decorated(buf, NO_DECOR)?;
+            self.intro.encode_decorated(buf, NO_DECOR)?;
             key_expr.encode_decorated(buf, BOTH_SPACE_DECOR)?;
             buf.write_str("=>")?;
-            self.value_expr()
-                .encode_decorated(buf, LEADING_SPACE_DECOR)?;
-            if self.grouping() {
+            self.value_expr.encode_decorated(buf, LEADING_SPACE_DECOR)?;
+            if self.grouping {
                 buf.write_str("...")?;
             }
-            if let Some(cond) = self.cond() {
+            if let Some(cond) = &self.cond {
                 cond.encode_decorated(buf, LEADING_SPACE_DECOR)?;
             }
             buf.write_char('}')
         } else {
             // list expr
             buf.write_char('[')?;
-            self.intro().encode_decorated(buf, NO_DECOR)?;
-            self.value_expr()
-                .encode_decorated(buf, LEADING_SPACE_DECOR)?;
-            if let Some(cond) = self.cond() {
+            self.intro.encode_decorated(buf, NO_DECOR)?;
+            self.value_expr.encode_decorated(buf, LEADING_SPACE_DECOR)?;
+            if let Some(cond) = &self.cond {
                 cond.encode_decorated(buf, LEADING_SPACE_DECOR)?;
             }
             buf.write_char(']')
@@ -155,14 +153,13 @@ impl Encode for ForExpr {
 impl Encode for ForIntro {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
         buf.write_str("for")?;
-        if let Some(key_var) = self.key_var() {
+        if let Some(key_var) = &self.key_var {
             key_var.encode_decorated(buf, LEADING_SPACE_DECOR)?;
             buf.write_char(',')?;
         }
-        self.value_var()
-            .encode_decorated(buf, LEADING_SPACE_DECOR)?;
+        self.value_var.encode_decorated(buf, LEADING_SPACE_DECOR)?;
         buf.write_str("in")?;
-        self.collection_expr()
+        self.collection_expr
             .encode_decorated(buf, BOTH_SPACE_DECOR)?;
         buf.write_char(':')
     }
@@ -171,25 +168,24 @@ impl Encode for ForIntro {
 impl Encode for ForCond {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
         buf.write_str("if")?;
-        self.expr().encode_decorated(buf, LEADING_SPACE_DECOR)
+        self.expr.encode_decorated(buf, LEADING_SPACE_DECOR)
     }
 }
 
 impl Encode for Conditional {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        self.cond_expr()
-            .encode_decorated(buf, TRAILING_SPACE_DECOR)?;
+        self.cond_expr.encode_decorated(buf, TRAILING_SPACE_DECOR)?;
         buf.write_char('?')?;
-        self.true_expr().encode_decorated(buf, BOTH_SPACE_DECOR)?;
+        self.true_expr.encode_decorated(buf, BOTH_SPACE_DECOR)?;
         buf.write_char(':')?;
-        self.false_expr().encode_decorated(buf, LEADING_SPACE_DECOR)
+        self.false_expr.encode_decorated(buf, LEADING_SPACE_DECOR)
     }
 }
 
 impl Encode for FuncCall {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        self.name().encode_decorated(buf, NO_DECOR)?;
-        self.args().encode_decorated(buf, NO_DECOR)
+        self.ident.encode_decorated(buf, NO_DECOR)?;
+        self.args.encode_decorated(buf, NO_DECOR)
     }
 }
 
@@ -223,25 +219,24 @@ impl Encode for FuncArgs {
 
 impl Encode for UnaryOp {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        buf.write_str(self.operator().as_str())?;
-        self.expr().encode_decorated(buf, NO_DECOR)
+        buf.write_str(self.operator.as_str())?;
+        self.expr.encode_decorated(buf, NO_DECOR)
     }
 }
 
 impl Encode for BinaryOp {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        self.lhs_expr()
-            .encode_decorated(buf, TRAILING_SPACE_DECOR)?;
-        buf.write_str(self.operator().as_str())?;
-        self.rhs_expr().encode_decorated(buf, LEADING_SPACE_DECOR)
+        self.lhs_expr.encode_decorated(buf, TRAILING_SPACE_DECOR)?;
+        buf.write_str(self.operator.as_str())?;
+        self.rhs_expr.encode_decorated(buf, LEADING_SPACE_DECOR)
     }
 }
 
 impl Encode for Traversal {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        self.expr().encode_decorated(buf, NO_DECOR)?;
+        self.expr.encode_decorated(buf, NO_DECOR)?;
 
-        for operator in self.operators() {
+        for operator in &self.operators {
             operator.encode_decorated(buf, NO_DECOR)?;
         }
 

--- a/crates/hcl-edit/src/encode/structure.rs
+++ b/crates/hcl-edit/src/encode/structure.rs
@@ -27,21 +27,21 @@ impl EncodeDecorated for Structure {
 
 impl Encode for Attribute {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        self.key().encode_decorated(buf, TRAILING_SPACE_DECOR)?;
+        self.key.encode_decorated(buf, TRAILING_SPACE_DECOR)?;
         buf.write_char('=')?;
-        self.expr().encode_decorated(buf, LEADING_SPACE_DECOR)
+        self.value.encode_decorated(buf, LEADING_SPACE_DECOR)
     }
 }
 
 impl Encode for Block {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        self.ident().encode_decorated(buf, TRAILING_SPACE_DECOR)?;
+        self.ident.encode_decorated(buf, TRAILING_SPACE_DECOR)?;
 
-        for label in self.labels() {
+        for label in &self.labels {
             label.encode_decorated(buf, TRAILING_SPACE_DECOR)?;
         }
 
-        self.body().encode(buf)
+        self.body.encode(buf)
     }
 }
 

--- a/crates/hcl-edit/src/encode/template.rs
+++ b/crates/hcl-edit/src/encode/template.rs
@@ -35,22 +35,22 @@ impl Encode for HeredocTemplate {
             buf.write_char('-')?;
         }
 
-        writeln!(buf, "{}", self.delimiter().as_str())?;
+        writeln!(buf, "{}", self.delimiter.as_str())?;
 
         match self.indent() {
             Some(n) => {
                 let mut indent_buf = String::new();
                 let mut indent_state = EncodeState::new(&mut indent_buf);
-                self.template().encode(&mut indent_state)?;
+                self.template.encode(&mut indent_state)?;
                 let indented = indent_by(&indent_buf, n, false);
                 buf.write_str(&indented)?;
             }
-            None => self.template().encode(buf)?,
+            None => self.template.encode(buf)?,
         }
 
         self.trailing().encode_with_default(buf, "")?;
 
-        write!(buf, "{}", self.delimiter().as_str())
+        write!(buf, "{}", self.delimiter.as_str())
     }
 }
 
@@ -82,8 +82,8 @@ impl Encode for Element {
 
 impl Encode for Interpolation {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        encode_strip(buf, INTERPOLATION_START, self.strip(), |buf| {
-            self.expr().encode_decorated(buf, BOTH_SPACE_DECOR)
+        encode_strip(buf, INTERPOLATION_START, self.strip, |buf| {
+            self.expr.encode_decorated(buf, BOTH_SPACE_DECOR)
         })
     }
 }
@@ -99,39 +99,39 @@ impl Encode for Directive {
 
 impl Encode for IfDirective {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        self.if_expr().encode(buf)?;
-        if let Some(else_expr) = self.else_expr() {
+        self.if_expr.encode(buf)?;
+        if let Some(else_expr) = &self.else_expr {
             else_expr.encode(buf)?;
         }
-        self.endif_expr().encode(buf)
+        self.endif_expr.encode(buf)
     }
 }
 
 impl Encode for IfTemplateExpr {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        encode_strip(buf, DIRECTIVE_START, self.strip(), |buf| {
+        encode_strip(buf, DIRECTIVE_START, self.strip, |buf| {
             self.preamble().encode_with_default(buf, " ")?;
             buf.write_str("if")?;
-            self.cond_expr().encode_decorated(buf, TRAILING_SPACE_DECOR)
+            self.cond_expr.encode_decorated(buf, TRAILING_SPACE_DECOR)
         })?;
-        self.template().encode(buf)
+        self.template.encode(buf)
     }
 }
 
 impl Encode for ElseTemplateExpr {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        encode_strip(buf, DIRECTIVE_START, self.strip(), |buf| {
+        encode_strip(buf, DIRECTIVE_START, self.strip, |buf| {
             self.preamble().encode_with_default(buf, " ")?;
             buf.write_str("else")?;
             self.trailing().encode_with_default(buf, " ")
         })?;
-        self.template().encode(buf)
+        self.template.encode(buf)
     }
 }
 
 impl Encode for EndifTemplateExpr {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        encode_strip(buf, DIRECTIVE_START, self.strip(), |buf| {
+        encode_strip(buf, DIRECTIVE_START, self.strip, |buf| {
             self.preamble().encode_with_default(buf, " ")?;
             buf.write_str("endif")?;
             self.trailing().encode_with_default(buf, " ")
@@ -141,34 +141,33 @@ impl Encode for EndifTemplateExpr {
 
 impl Encode for ForDirective {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        self.for_expr().encode(buf)?;
-        self.endfor_expr().encode(buf)
+        self.for_expr.encode(buf)?;
+        self.endfor_expr.encode(buf)
     }
 }
 
 impl Encode for ForTemplateExpr {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        encode_strip(buf, DIRECTIVE_START, self.strip(), |buf| {
+        encode_strip(buf, DIRECTIVE_START, self.strip, |buf| {
             self.preamble().encode_with_default(buf, " ")?;
             buf.write_str("for")?;
 
-            if let Some(key_var) = self.key_var() {
+            if let Some(key_var) = &self.key_var {
                 key_var.encode_decorated(buf, LEADING_SPACE_DECOR)?;
                 buf.write_char(',')?;
             }
 
-            self.value_var().encode_decorated(buf, BOTH_SPACE_DECOR)?;
+            self.value_var.encode_decorated(buf, BOTH_SPACE_DECOR)?;
             buf.write_str("in")?;
-            self.collection_expr()
-                .encode_decorated(buf, BOTH_SPACE_DECOR)
+            self.collection_expr.encode_decorated(buf, BOTH_SPACE_DECOR)
         })?;
-        self.template().encode(buf)
+        self.template.encode(buf)
     }
 }
 
 impl Encode for EndforTemplateExpr {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        encode_strip(buf, DIRECTIVE_START, self.strip(), |buf| {
+        encode_strip(buf, DIRECTIVE_START, self.strip, |buf| {
             self.preamble().encode_with_default(buf, " ")?;
             buf.write_str("endfor")?;
             self.trailing().encode_with_default(buf, " ")

--- a/crates/hcl-edit/src/expr/mod.rs
+++ b/crates/hcl-edit/src/expr/mod.rs
@@ -23,10 +23,6 @@ pub type ObjectIter<'a> = Box<dyn Iterator<Item = (&'a ObjectKey, &'a ObjectValu
 
 pub type ObjectIterMut<'a> = Box<dyn Iterator<Item = (&'a ObjectKey, &'a mut ObjectValue)> + 'a>;
 
-pub type TraversalIter<'a> = Box<dyn Iterator<Item = &'a Decorated<TraversalOperator>> + 'a>;
-
-pub type TraversalIterMut<'a> = Box<dyn Iterator<Item = &'a mut Decorated<TraversalOperator>> + 'a>;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expression {
     Null(Decorated<Null>),
@@ -457,9 +453,10 @@ impl From<Expression> for ObjectValue {
 
 #[derive(Debug, Clone, Eq)]
 pub struct Conditional {
-    cond_expr: Expression,
-    true_expr: Expression,
-    false_expr: Expression,
+    pub cond_expr: Expression,
+    pub true_expr: Expression,
+    pub false_expr: Expression,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
@@ -477,18 +474,6 @@ impl Conditional {
             decor: Decor::default(),
             span: None,
         }
-    }
-
-    pub fn cond_expr(&self) -> &Expression {
-        &self.cond_expr
-    }
-
-    pub fn true_expr(&self) -> &Expression {
-        &self.true_expr
-    }
-
-    pub fn false_expr(&self) -> &Expression {
-        &self.false_expr
     }
 
     pub(crate) fn despan(&mut self, input: &str) {
@@ -509,44 +494,33 @@ impl PartialEq for Conditional {
 
 #[derive(Debug, Clone, Eq)]
 pub struct FuncCall {
-    name: Decorated<Ident>,
-    args: FuncArgs,
+    pub ident: Decorated<Ident>,
+    pub args: FuncArgs,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
 
 impl FuncCall {
-    pub fn new(name: Decorated<Ident>, args: FuncArgs) -> FuncCall {
+    pub fn new(ident: Decorated<Ident>, args: FuncArgs) -> FuncCall {
         FuncCall {
-            name,
+            ident,
             args,
             decor: Decor::default(),
             span: None,
         }
     }
 
-    pub fn name(&self) -> &Decorated<Ident> {
-        &self.name
-    }
-
-    pub fn args(&self) -> &FuncArgs {
-        &self.args
-    }
-
-    pub fn args_mut(&mut self) -> &mut FuncArgs {
-        &mut self.args
-    }
-
     pub(crate) fn despan(&mut self, input: &str) {
         self.decor.despan(input);
-        self.name.decor_mut().despan(input);
+        self.ident.decor_mut().despan(input);
         self.args.despan(input);
     }
 }
 
 impl PartialEq for FuncCall {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.args == other.args
+        self.ident == other.ident && self.args == other.args
     }
 }
 
@@ -628,8 +602,9 @@ impl PartialEq for FuncArgs {
 
 #[derive(Debug, Clone, Eq)]
 pub struct Traversal {
-    expr: Expression,
-    operators: Vec<Decorated<TraversalOperator>>,
+    pub expr: Expression,
+    pub operators: Vec<Decorated<TraversalOperator>>,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
@@ -642,18 +617,6 @@ impl Traversal {
             decor: Decor::default(),
             span: None,
         }
-    }
-
-    pub fn expr(&self) -> &Expression {
-        &self.expr
-    }
-
-    pub fn operators(&self) -> TraversalIter<'_> {
-        Box::new(self.operators.iter())
-    }
-
-    pub fn operators_mut(&mut self) -> TraversalIterMut<'_> {
-        Box::new(self.operators.iter_mut())
     }
 
     pub(crate) fn despan(&mut self, input: &str) {
@@ -714,8 +677,9 @@ impl TraversalOperator {
 
 #[derive(Debug, Clone, Eq)]
 pub struct UnaryOp {
-    operator: Spanned<UnaryOperator>,
-    expr: Expression,
+    pub operator: Spanned<UnaryOperator>,
+    pub expr: Expression,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
@@ -728,14 +692,6 @@ impl UnaryOp {
             decor: Decor::default(),
             span: None,
         }
-    }
-
-    pub fn operator(&self) -> &Spanned<UnaryOperator> {
-        &self.operator
-    }
-
-    pub fn expr(&self) -> &Expression {
-        &self.expr
     }
 
     pub(crate) fn despan(&mut self, input: &str) {
@@ -752,9 +708,10 @@ impl PartialEq for UnaryOp {
 
 #[derive(Debug, Clone, Eq)]
 pub struct BinaryOp {
-    lhs_expr: Expression,
-    operator: Spanned<BinaryOperator>,
-    rhs_expr: Expression,
+    pub lhs_expr: Expression,
+    pub operator: Spanned<BinaryOperator>,
+    pub rhs_expr: Expression,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
@@ -774,18 +731,6 @@ impl BinaryOp {
         }
     }
 
-    pub fn lhs_expr(&self) -> &Expression {
-        &self.lhs_expr
-    }
-
-    pub fn operator(&self) -> &Spanned<BinaryOperator> {
-        &self.operator
-    }
-
-    pub fn rhs_expr(&self) -> &Expression {
-        &self.rhs_expr
-    }
-
     pub(crate) fn despan(&mut self, input: &str) {
         self.decor.despan(input);
         self.lhs_expr.despan(input);
@@ -803,11 +748,12 @@ impl PartialEq for BinaryOp {
 
 #[derive(Debug, Clone, Eq)]
 pub struct ForExpr {
-    intro: ForIntro,
-    key_expr: Option<Expression>,
-    value_expr: Expression,
-    grouping: bool,
-    cond: Option<ForCond>,
+    pub intro: ForIntro,
+    pub key_expr: Option<Expression>,
+    pub value_expr: Expression,
+    pub grouping: bool,
+    pub cond: Option<ForCond>,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
@@ -823,38 +769,6 @@ impl ForExpr {
             decor: Decor::default(),
             span: None,
         }
-    }
-
-    pub fn intro(&self) -> &ForIntro {
-        &self.intro
-    }
-
-    pub fn key_expr(&self) -> Option<&Expression> {
-        self.key_expr.as_ref()
-    }
-
-    pub fn set_key_expr(&mut self, key_expr: Expression) {
-        self.key_expr = Some(key_expr);
-    }
-
-    pub fn value_expr(&self) -> &Expression {
-        &self.value_expr
-    }
-
-    pub fn grouping(&self) -> bool {
-        self.grouping
-    }
-
-    pub fn set_grouping(&mut self, yes: bool) {
-        self.grouping = yes;
-    }
-
-    pub fn cond(&self) -> Option<&ForCond> {
-        self.cond.as_ref()
-    }
-
-    pub fn set_cond(&mut self, cond: ForCond) {
-        self.cond = Some(cond);
     }
 
     pub(crate) fn despan(&mut self, input: &str) {
@@ -885,9 +799,10 @@ impl PartialEq for ForExpr {
 
 #[derive(Debug, Clone, Eq)]
 pub struct ForIntro {
-    key_var: Option<Decorated<Ident>>,
-    value_var: Decorated<Ident>,
-    collection_expr: Expression,
+    pub key_var: Option<Decorated<Ident>>,
+    pub value_var: Decorated<Ident>,
+    pub collection_expr: Expression,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
@@ -901,22 +816,6 @@ impl ForIntro {
             decor: Decor::default(),
             span: None,
         }
-    }
-
-    pub fn key_var(&self) -> Option<&Decorated<Ident>> {
-        self.key_var.as_ref()
-    }
-
-    pub fn set_key_var(&mut self, key_var: Decorated<Ident>) {
-        self.key_var = Some(key_var);
-    }
-
-    pub fn value_var(&self) -> &Decorated<Ident> {
-        &self.value_var
-    }
-
-    pub fn collection_expr(&self) -> &Expression {
-        &self.collection_expr
     }
 
     pub(crate) fn despan(&mut self, input: &str) {
@@ -940,7 +839,8 @@ impl PartialEq for ForIntro {
 
 #[derive(Debug, Clone, Eq)]
 pub struct ForCond {
-    expr: Expression,
+    pub expr: Expression,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
@@ -952,10 +852,6 @@ impl ForCond {
             decor: Decor::default(),
             span: None,
         }
-    }
-
-    pub fn expr(&self) -> &Expression {
-        &self.expr
     }
 
     pub(crate) fn despan(&mut self, input: &str) {

--- a/crates/hcl-edit/src/parser/expr.rs
+++ b/crates/hcl-edit/src/parser/expr.rs
@@ -304,10 +304,7 @@ fn for_list_expr<'i, 's>(
         (for_intro, decorated(ws, expr, ws), opt(for_cond))
             .map(|(intro, value_expr, cond)| {
                 let mut expr = ForExpr::new(intro, value_expr);
-
-                if let Some(cond) = cond {
-                    expr.set_cond(cond);
-                }
+                expr.cond = cond;
 
                 state
                     .borrow_mut()
@@ -366,12 +363,9 @@ fn for_object_expr<'i, 's>(
         )
             .map(|(intro, (key_expr, value_expr), grouping, cond)| {
                 let mut expr = ForExpr::new(intro, value_expr);
-                expr.set_key_expr(key_expr);
-                expr.set_grouping(grouping.is_some());
-
-                if let Some(cond) = cond {
-                    expr.set_cond(cond);
-                }
+                expr.key_expr = Some(key_expr);
+                expr.grouping = grouping.is_some();
+                expr.cond = cond;
 
                 state
                     .borrow_mut()
@@ -517,7 +511,7 @@ fn for_intro(input: Input) -> IResult<Input, ForIntro> {
         .map(|(first, second, expr)| match second {
             Some(second) => {
                 let mut intro = ForIntro::new(second, expr);
-                intro.set_key_var(first);
+                intro.key_var = Some(first);
                 intro
             }
             None => ForIntro::new(first, expr),
@@ -599,9 +593,9 @@ fn identlike<'i, 's>(
             .map(|((ident, span), func_args)| {
                 let expr = match func_args {
                     Some(func_args) => {
-                        let mut name = Decorated::new(Ident::new_unchecked(ident));
-                        name.set_span(span);
-                        let func_call = FuncCall::new(name, func_args);
+                        let mut ident = Decorated::new(Ident::new_unchecked(ident));
+                        ident.set_span(span);
+                        let func_call = FuncCall::new(ident, func_args);
                         Expression::FuncCall(Box::new(func_call))
                     }
                     None => match ident {

--- a/crates/hcl-edit/src/parser/structure.rs
+++ b/crates/hcl-edit/src/parser/structure.rs
@@ -75,7 +75,7 @@ fn structure<'i, 's>(
                 let (input, labels) = block_labels(input)?;
                 let (input, body) = block_body(input)?;
                 let mut block = Block::new(ident, body);
-                block.set_labels(labels);
+                block.labels = labels;
                 (input, Structure::Block(block))
             }
             _ => {

--- a/crates/hcl-edit/src/parser/template.rs
+++ b/crates/hcl-edit/src/parser/template.rs
@@ -91,7 +91,7 @@ fn interpolation(input: Input) -> IResult<Input, Interpolation> {
     control(b"${", decorated(ws, expr, ws))
         .map(|(expr, strip)| {
             let mut interp = Interpolation::new(expr);
-            interp.set_strip(strip);
+            interp.strip = strip;
             interp
         })
         .parse_next(input)
@@ -115,7 +115,7 @@ fn if_directive(input: Input) -> IResult<Input, IfDirective> {
     )
         .map(|(((preamble, cond_expr), strip), template)| {
             let mut expr = IfTemplateExpr::new(cond_expr, template);
-            expr.set_strip(strip);
+            expr.strip = strip;
             expr.set_preamble(preamble);
             expr
         });
@@ -129,7 +129,7 @@ fn if_directive(input: Input) -> IResult<Input, IfDirective> {
     )
         .map(|(((preamble, trailing), strip), template)| {
             let mut expr = ElseTemplateExpr::new(template);
-            expr.set_strip(strip);
+            expr.strip = strip;
             expr.set_preamble(preamble);
             expr.set_trailing(trailing);
             expr
@@ -141,7 +141,7 @@ fn if_directive(input: Input) -> IResult<Input, IfDirective> {
     )
     .map(|((preamble, trailing), strip)| {
         let mut expr = EndifTemplateExpr::new();
-        expr.set_strip(strip);
+        expr.strip = strip;
         expr.set_preamble(preamble);
         expr.set_trailing(trailing);
         expr
@@ -173,7 +173,7 @@ fn for_directive(input: Input) -> IResult<Input, ForDirective> {
                 };
 
                 let mut expr = ForTemplateExpr::new(key_var, value_var, collection_expr, template);
-                expr.set_strip(strip);
+                expr.strip = strip;
                 expr.set_preamble(preamble);
                 expr
             },
@@ -185,7 +185,7 @@ fn for_directive(input: Input) -> IResult<Input, ForDirective> {
     )
     .map(|((preamble, trailing), strip)| {
         let mut expr = EndforTemplateExpr::new();
-        expr.set_strip(strip);
+        expr.strip = strip;
         expr.set_preamble(preamble);
         expr.set_trailing(trailing);
         expr

--- a/crates/hcl-edit/src/structure/mod.rs
+++ b/crates/hcl-edit/src/structure/mod.rs
@@ -14,10 +14,6 @@ pub type Iter<'a> = Box<dyn Iterator<Item = &'a Structure> + 'a>;
 
 pub type IterMut<'a> = Box<dyn Iterator<Item = &'a mut Structure> + 'a>;
 
-pub type LabelIter<'a> = Box<dyn Iterator<Item = &'a BlockLabel> + 'a>;
-
-pub type LabelIterMut<'a> = Box<dyn Iterator<Item = &'a mut BlockLabel> + 'a>;
-
 #[derive(Debug, Clone, Default, Eq)]
 pub struct Body {
     structures: Vec<Structure>,
@@ -137,48 +133,42 @@ impl Structure {
 
 #[derive(Debug, Clone, Eq)]
 pub struct Attribute {
-    key: Decorated<Ident>,
-    expr: Expression,
+    pub key: Decorated<Ident>,
+    pub value: Expression,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
 
 impl Attribute {
-    pub fn new(key: Decorated<Ident>, expr: Expression) -> Attribute {
+    pub fn new(key: Decorated<Ident>, value: Expression) -> Attribute {
         Attribute {
             key,
-            expr,
+            value,
             decor: Decor::default(),
             span: None,
         }
     }
 
-    pub fn key(&self) -> &Decorated<Ident> {
-        &self.key
-    }
-
-    pub fn expr(&self) -> &Expression {
-        &self.expr
-    }
-
     pub(crate) fn despan(&mut self, input: &str) {
         self.decor.despan(input);
         self.key.decor_mut().despan(input);
-        self.expr.despan(input);
+        self.value.despan(input);
     }
 }
 
 impl PartialEq for Attribute {
     fn eq(&self, other: &Self) -> bool {
-        self.key == other.key && self.expr == other.expr
+        self.key == other.key && self.value == other.value
     }
 }
 
 #[derive(Debug, Clone, Eq)]
 pub struct Block {
-    identifier: Decorated<Ident>,
-    labels: Vec<BlockLabel>,
-    body: BlockBody,
+    pub ident: Decorated<Ident>,
+    pub labels: Vec<BlockLabel>,
+    pub body: BlockBody,
+
     decor: Decor,
     span: Option<Range<usize>>,
 }
@@ -186,7 +176,7 @@ pub struct Block {
 impl Block {
     pub fn new(ident: Decorated<Ident>, body: BlockBody) -> Block {
         Block {
-            identifier: ident,
+            ident,
             labels: Vec::new(),
             body,
             decor: Decor::default(),
@@ -194,33 +184,9 @@ impl Block {
         }
     }
 
-    pub fn ident(&self) -> &Decorated<Ident> {
-        &self.identifier
-    }
-
-    pub fn labels(&self) -> LabelIter<'_> {
-        Box::new(self.labels.iter())
-    }
-
-    pub fn labels_mut(&mut self) -> LabelIterMut<'_> {
-        Box::new(self.labels.iter_mut())
-    }
-
-    pub fn set_labels(&mut self, labels: Vec<BlockLabel>) {
-        self.labels = labels;
-    }
-
-    pub fn body(&self) -> &BlockBody {
-        &self.body
-    }
-
-    pub fn body_mut(&mut self) -> &mut BlockBody {
-        &mut self.body
-    }
-
     pub(crate) fn despan(&mut self, input: &str) {
         self.decor.despan(input);
-        self.identifier.decor_mut().despan(input);
+        self.ident.decor_mut().despan(input);
         for label in &mut self.labels {
             label.despan(input);
         }
@@ -230,9 +196,7 @@ impl Block {
 
 impl PartialEq for Block {
     fn eq(&self, other: &Self) -> bool {
-        self.identifier == other.identifier
-            && self.labels == other.labels
-            && self.body == other.body
+        self.ident == other.ident && self.labels == other.labels && self.body == other.body
     }
 }
 

--- a/crates/hcl-edit/src/template/mod.rs
+++ b/crates/hcl-edit/src/template/mod.rs
@@ -65,8 +65,9 @@ impl PartialEq for StringTemplate {
 
 #[derive(Debug, Clone, Eq)]
 pub struct HeredocTemplate {
-    delimiter: Ident,
-    template: Template,
+    pub delimiter: Ident,
+    pub template: Template,
+
     indent: Option<usize>,
     trailing: RawString,
     decor: Decor,
@@ -83,14 +84,6 @@ impl HeredocTemplate {
             decor: Decor::default(),
             span: None,
         }
-    }
-
-    pub fn delimiter(&self) -> &Ident {
-        &self.delimiter
-    }
-
-    pub fn template(&self) -> &Template {
-        &self.template
     }
 
     pub fn indent(&self) -> Option<usize> {
@@ -231,8 +224,9 @@ impl Element {
 
 #[derive(Debug, Clone, Eq)]
 pub struct Interpolation {
-    expr: Expression,
-    strip: Strip,
+    pub expr: Expression,
+    pub strip: Strip,
+
     span: Option<Range<usize>>,
 }
 
@@ -243,18 +237,6 @@ impl Interpolation {
             strip: Strip::default(),
             span: None,
         }
-    }
-
-    pub fn expr(&self) -> &Expression {
-        &self.expr
-    }
-
-    pub fn strip(&self) -> Strip {
-        self.strip
-    }
-
-    pub fn set_strip(&mut self, strip: Strip) {
-        self.strip = strip;
     }
 
     pub(crate) fn despan(&mut self, input: &str) {
@@ -285,9 +267,10 @@ impl Directive {
 
 #[derive(Debug, Clone, Eq)]
 pub struct IfDirective {
-    if_expr: IfTemplateExpr,
-    else_expr: Option<ElseTemplateExpr>,
-    endif_expr: EndifTemplateExpr,
+    pub if_expr: IfTemplateExpr,
+    pub else_expr: Option<ElseTemplateExpr>,
+    pub endif_expr: EndifTemplateExpr,
+
     span: Option<Range<usize>>,
 }
 
@@ -303,18 +286,6 @@ impl IfDirective {
             endif_expr,
             span: None,
         }
-    }
-
-    pub fn if_expr(&self) -> &IfTemplateExpr {
-        &self.if_expr
-    }
-
-    pub fn else_expr(&self) -> Option<&ElseTemplateExpr> {
-        self.else_expr.as_ref()
-    }
-
-    pub fn endif_expr(&self) -> &EndifTemplateExpr {
-        &self.endif_expr
     }
 
     pub(crate) fn despan(&mut self, input: &str) {
@@ -338,10 +309,11 @@ impl PartialEq for IfDirective {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IfTemplateExpr {
+    pub cond_expr: Expression,
+    pub template: Template,
+    pub strip: Strip,
+
     preamble: RawString,
-    cond_expr: Expression,
-    template: Template,
-    strip: Strip,
 }
 
 impl IfTemplateExpr {
@@ -352,22 +324,6 @@ impl IfTemplateExpr {
             template,
             strip: Strip::default(),
         }
-    }
-
-    pub fn cond_expr(&self) -> &Expression {
-        &self.cond_expr
-    }
-
-    pub fn template(&self) -> &Template {
-        &self.template
-    }
-
-    pub fn strip(&self) -> Strip {
-        self.strip
-    }
-
-    pub fn set_strip(&mut self, strip: Strip) {
-        self.strip = strip;
     }
 
     pub fn preamble(&self) -> &RawString {
@@ -387,10 +343,11 @@ impl IfTemplateExpr {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ElseTemplateExpr {
+    pub template: Template,
+    pub strip: Strip,
+
     preamble: RawString,
     trailing: RawString,
-    template: Template,
-    strip: Strip,
 }
 
 impl ElseTemplateExpr {
@@ -401,18 +358,6 @@ impl ElseTemplateExpr {
             template,
             strip: Strip::default(),
         }
-    }
-
-    pub fn template(&self) -> &Template {
-        &self.template
-    }
-
-    pub fn strip(&self) -> Strip {
-        self.strip
-    }
-
-    pub fn set_strip(&mut self, strip: Strip) {
-        self.strip = strip;
     }
 
     pub fn preamble(&self) -> &RawString {
@@ -440,22 +385,15 @@ impl ElseTemplateExpr {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EndifTemplateExpr {
+    pub strip: Strip,
+
     preamble: RawString,
     trailing: RawString,
-    strip: Strip,
 }
 
 impl EndifTemplateExpr {
     pub fn new() -> EndifTemplateExpr {
         EndifTemplateExpr::default()
-    }
-
-    pub fn strip(&self) -> Strip {
-        self.strip
-    }
-
-    pub fn set_strip(&mut self, strip: Strip) {
-        self.strip = strip;
     }
 
     pub fn preamble(&self) -> &RawString {
@@ -482,8 +420,9 @@ impl EndifTemplateExpr {
 
 #[derive(Debug, Clone, Eq)]
 pub struct ForDirective {
-    for_expr: ForTemplateExpr,
-    endfor_expr: EndforTemplateExpr,
+    pub for_expr: ForTemplateExpr,
+    pub endfor_expr: EndforTemplateExpr,
+
     span: Option<Range<usize>>,
 }
 
@@ -494,14 +433,6 @@ impl ForDirective {
             endfor_expr,
             span: None,
         }
-    }
-
-    pub fn for_expr(&self) -> &ForTemplateExpr {
-        &self.for_expr
-    }
-
-    pub fn endfor_expr(&self) -> &EndforTemplateExpr {
-        &self.endfor_expr
     }
 
     pub(crate) fn despan(&mut self, input: &str) {
@@ -518,12 +449,13 @@ impl PartialEq for ForDirective {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForTemplateExpr {
+    pub key_var: Option<Decorated<Ident>>,
+    pub value_var: Decorated<Ident>,
+    pub collection_expr: Expression,
+    pub template: Template,
+    pub strip: Strip,
+
     preamble: RawString,
-    key_var: Option<Decorated<Ident>>,
-    value_var: Decorated<Ident>,
-    collection_expr: Expression,
-    template: Template,
-    strip: Strip,
 }
 
 impl ForTemplateExpr {
@@ -541,30 +473,6 @@ impl ForTemplateExpr {
             template,
             strip: Strip::default(),
         }
-    }
-
-    pub fn key_var(&self) -> Option<&Decorated<Ident>> {
-        self.key_var.as_ref()
-    }
-
-    pub fn value_var(&self) -> &Decorated<Ident> {
-        &self.value_var
-    }
-
-    pub fn collection_expr(&self) -> &Expression {
-        &self.collection_expr
-    }
-
-    pub fn template(&self) -> &Template {
-        &self.template
-    }
-
-    pub fn strip(&self) -> Strip {
-        self.strip
-    }
-
-    pub fn set_strip(&mut self, strip: Strip) {
-        self.strip = strip;
     }
 
     pub fn preamble(&self) -> &RawString {
@@ -590,22 +498,15 @@ impl ForTemplateExpr {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EndforTemplateExpr {
+    pub strip: Strip,
+
     preamble: RawString,
     trailing: RawString,
-    strip: Strip,
 }
 
 impl EndforTemplateExpr {
     pub fn new() -> EndforTemplateExpr {
         EndforTemplateExpr::default()
-    }
-
-    pub fn strip(&self) -> Strip {
-        self.strip
-    }
-
-    pub fn set_strip(&mut self, strip: Strip) {
-        self.strip = strip;
     }
 
     pub fn preamble(&self) -> &RawString {


### PR DESCRIPTION
This makes most of the getters and setters obsolete and will also allow mutable borrows to multiple fields at the same time, which will simplify implementing visitors in a followup PR.