### PR TITLE
feat: add `visit` and `visit_mut` modules

### DIFF
--- a/crates/hcl-edit/README.md
+++ b/crates/hcl-edit/README.md
@@ -20,6 +20,16 @@ This will improve over time as this project evolves.
 
 **Expect breaking changes at any time** until the biggest issues are fleshed out.
 
+## HCL document traversal
+
+The [`visit`](https://docs.rs/hcl-edit/latest/hcl_edit/visit/index.html) module
+allows traversal of language items within a HCL document. Mutable document
+traversal is supported via the
+[`visit_mut`](https://docs.rs/hcl-edit/latest/hcl_edit/visit_mut/index.html)
+module.
+
+See the respective module's documentation for more.
+
 ## Contributing
 
 Contributions are welcome! Please read

--- a/crates/hcl-edit/src/expr/mod.rs
+++ b/crates/hcl-edit/src/expr/mod.rs
@@ -110,6 +110,12 @@ impl From<Parenthesis> for Expression {
     }
 }
 
+impl From<Traversal> for Expression {
+    fn from(traversal: Traversal) -> Self {
+        Expression::Traversal(Box::new(traversal))
+    }
+}
+
 impl fmt::Display for Expression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut state = EncodeState::new(f);

--- a/crates/hcl-edit/src/lib.rs
+++ b/crates/hcl-edit/src/lib.rs
@@ -15,6 +15,8 @@ pub mod repr;
 pub mod structure;
 pub mod template;
 mod util;
+pub mod visit;
+pub mod visit_mut;
 
 #[doc(inline)]
 pub use self::raw_string::RawString;

--- a/crates/hcl-edit/src/structure/mod.rs
+++ b/crates/hcl-edit/src/structure/mod.rs
@@ -308,6 +308,8 @@ impl BlockBody {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct OnelineBody {
+    // Always of variant `Structure::Attribute` if not `None`. It's wrapped in a `Structure` to
+    // support the creation of iterators over (mutable) `Structure` references in `BlockBody`.
     attr: Option<Structure>,
     trailing: RawString,
 }
@@ -321,12 +323,16 @@ impl OnelineBody {
         self.attr.is_none()
     }
 
-    pub fn set_attribute(&mut self, attr: Attribute) {
-        self.attr = Some(Structure::Attribute(attr))
+    pub fn set_attribute(&mut self, attr: impl Into<Attribute>) {
+        self.attr = Some(Structure::Attribute(attr.into()))
     }
 
     pub fn as_attribute(&self) -> Option<&Attribute> {
-        self.attr.as_ref().and_then(|s| s.as_attribute())
+        self.attr.as_ref().and_then(Structure::as_attribute)
+    }
+
+    pub fn as_attribute_mut(&mut self) -> Option<&mut Attribute> {
+        self.attr.as_mut().and_then(Structure::as_attribute_mut)
     }
 
     pub fn trailing(&self) -> &RawString {

--- a/crates/hcl-edit/src/visit.rs
+++ b/crates/hcl-edit/src/visit.rs
@@ -1,0 +1,494 @@
+//! HCL language item traversal.
+//!
+//! Each method of the [`Visit`] trait is a hook that can be overridden to customize the behavior
+//! when visiting the corresponding type of language item. By default, every method recursively
+//! visits the substructure of the AST by invoking the right visitor method of each of its fields.
+//!
+//! The API is modeled after [`syn::visit`](https://docs.rs/syn/latest/syn/visit/index.html). For a
+//! mutable alternative, see [`hcl_edit::visit_mut`](crate::visit_mut).
+//!
+//! # Examples
+//!
+//! Collect all referenced variables from a HCL document:
+//!
+//! ```
+//! # use std::error::Error;
+//! #
+//! # fn main() -> Result<(), Box<dyn Error>> {
+//! use hcl_edit::expr::Expression;
+//! use hcl_edit::structure::Body;
+//! use hcl_edit::visit::{visit_expr, Visit};
+//! use std::collections::HashSet;
+//! use std::str::FromStr;
+//!
+//! #[derive(Default)]
+//! struct VariableNameVisitor<'a> {
+//!     variable_names: HashSet<&'a str>,
+//! }
+//!
+//! impl<'ast> Visit<'ast> for VariableNameVisitor<'ast> {
+//!     fn visit_expr(&mut self, expr: &'ast Expression) {
+//!         if let Expression::Variable(var) = expr {
+//!             self.variable_names.insert(var.as_str());
+//!         } else {
+//!             // Recurse further down the AST.
+//!             visit_expr(self, expr);
+//!         }
+//!     }
+//! }
+//!
+//! let input = r#"
+//!     // A service definition.
+//!     service {
+//!         fullname        = "${namespace}/${name}"
+//!         health_endpoint = "${base_url}/health"
+//!     }
+//! "#;
+//!
+//! let body = input.parse::<Body>()?;
+//!
+//! let mut visitor = VariableNameVisitor::default();
+//!
+//! visitor.visit_body(&body);
+//!
+//! let expected = HashSet::from(["namespace", "name", "base_url"]);
+//!
+//! assert_eq!(visitor.variable_names, expected);
+//! #   Ok(())
+//! # }
+//! ```
+
+#![allow(missing_docs)]
+
+use crate::expr::{
+    Array, BinaryOp, BinaryOperator, Conditional, Expression, ForCond, ForExpr, ForIntro, FuncArgs,
+    FuncCall, Null, Object, ObjectKey, ObjectValue, Parenthesis, Splat, Traversal,
+    TraversalOperator, UnaryOp, UnaryOperator,
+};
+use crate::repr::{Decorated, Formatted, Spanned};
+use crate::structure::{Attribute, Block, BlockBody, BlockLabel, Body, OnelineBody, Structure};
+use crate::template::{
+    Directive, Element, ElseTemplateExpr, EndforTemplateExpr, EndifTemplateExpr, ForDirective,
+    ForTemplateExpr, HeredocTemplate, IfDirective, IfTemplateExpr, Interpolation, StringTemplate,
+    Template,
+};
+use crate::{Ident, Number};
+
+macro_rules! empty_visit_methods {
+    ($($name: ident => $t: ty),+ $(,)?) => {
+        $(
+            fn $name(&mut self, node: &'ast $t) {
+                let _ = node;
+            }
+        )*
+    };
+}
+
+macro_rules! visit_methods {
+    ($($name: ident => $t: ty),+ $(,)?) => {
+        $(
+            fn $name(&mut self, node: &'ast $t) {
+                $name(self, node);
+            }
+        )*
+    };
+}
+
+/// Traversal to walk a shared borrow of an HCL language item.
+///
+/// See the [module documentation](crate::visit) for details.
+pub trait Visit<'ast> {
+    empty_visit_methods! {
+        visit_ident => Decorated<Ident>,
+        visit_null => Decorated<Null>,
+        visit_bool => Decorated<bool>,
+        visit_u64 => Decorated<u64>,
+        visit_number => Formatted<Number>,
+        visit_string => Decorated<String>,
+        visit_splat => Decorated<Splat>,
+        visit_literal => Spanned<String>,
+        visit_unary_operator => Spanned<UnaryOperator>,
+        visit_binary_operator => Spanned<BinaryOperator>,
+        visit_endif_template_expr => EndifTemplateExpr,
+        visit_endfor_template_expr => EndforTemplateExpr,
+    }
+
+    visit_methods! {
+        visit_body => Body,
+        visit_structure => Structure,
+        visit_attr => Attribute,
+        visit_block => Block,
+        visit_block_label => BlockLabel,
+        visit_block_body => BlockBody,
+        visit_oneline_body => OnelineBody,
+        visit_expr => Expression,
+        visit_array => Array,
+        visit_object => Object,
+        visit_object_key => ObjectKey,
+        visit_object_value => ObjectValue,
+        visit_parenthesis => Parenthesis,
+        visit_conditional => Conditional,
+        visit_unary_op => UnaryOp,
+        visit_binary_op => BinaryOp,
+        visit_traversal => Traversal,
+        visit_traversal_operator => TraversalOperator,
+        visit_func_call => FuncCall,
+        visit_func_args => FuncArgs,
+        visit_for_expr => ForExpr,
+        visit_for_intro => ForIntro,
+        visit_for_cond => ForCond,
+        visit_string_template => StringTemplate,
+        visit_heredoc_template => HeredocTemplate,
+        visit_template => Template,
+        visit_element => Element,
+        visit_interpolation => Interpolation,
+        visit_directive => Directive,
+        visit_if_directive => IfDirective,
+        visit_for_directive => ForDirective,
+        visit_if_template_expr => IfTemplateExpr,
+        visit_else_template_expr => ElseTemplateExpr,
+        visit_for_template_expr => ForTemplateExpr,
+    }
+
+    fn visit_object_item(&mut self, key: &'ast ObjectKey, value: &'ast ObjectValue) {
+        visit_object_item(self, key, value);
+    }
+}
+
+pub fn visit_body<'ast, V>(v: &mut V, node: &'ast Body)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for structure in node.iter() {
+        v.visit_structure(structure);
+    }
+}
+
+pub fn visit_structure<'ast, V>(v: &mut V, node: &'ast Structure)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        Structure::Attribute(attr) => v.visit_attr(attr),
+        Structure::Block(block) => v.visit_block(block),
+    }
+}
+
+pub fn visit_attr<'ast, V>(v: &mut V, node: &'ast Attribute)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_ident(&node.key);
+    v.visit_expr(&node.value);
+}
+
+pub fn visit_block<'ast, V>(v: &mut V, node: &'ast Block)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_ident(&node.ident);
+    for label in &node.labels {
+        v.visit_block_label(label);
+    }
+    v.visit_block_body(&node.body);
+}
+
+pub fn visit_block_label<'ast, V>(v: &mut V, node: &'ast BlockLabel)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        BlockLabel::String(string) => v.visit_string(string),
+        BlockLabel::Ident(ident) => v.visit_ident(ident),
+    }
+}
+
+pub fn visit_block_body<'ast, V>(v: &mut V, node: &'ast BlockBody)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        BlockBody::Oneline(oneline) => v.visit_oneline_body(oneline),
+        BlockBody::Multiline(body) => v.visit_body(body),
+    }
+}
+
+pub fn visit_oneline_body<'ast, V>(v: &mut V, node: &'ast OnelineBody)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    if let Some(attr) = node.as_attribute() {
+        v.visit_attr(attr);
+    }
+}
+
+pub fn visit_expr<'ast, V>(v: &mut V, node: &'ast Expression)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        Expression::Null(null) => v.visit_null(null),
+        Expression::Bool(b) => v.visit_bool(b),
+        Expression::Number(number) => v.visit_number(number),
+        Expression::String(string) => v.visit_string(string),
+        Expression::Array(array) => v.visit_array(array),
+        Expression::Object(object) => v.visit_object(object),
+        Expression::Template(template) => v.visit_string_template(template),
+        Expression::HeredocTemplate(template) => v.visit_heredoc_template(template),
+        Expression::Parenthesis(parens) => v.visit_parenthesis(parens),
+        Expression::Variable(var) => v.visit_ident(var),
+        Expression::ForExpr(for_expr) => v.visit_for_expr(for_expr),
+        Expression::Conditional(conditional) => v.visit_conditional(conditional),
+        Expression::FuncCall(func_call) => v.visit_func_call(func_call),
+        Expression::UnaryOp(unary_op) => v.visit_unary_op(unary_op),
+        Expression::BinaryOp(binary_op) => v.visit_binary_op(binary_op),
+        Expression::Traversal(traversal) => v.visit_traversal(traversal),
+    }
+}
+
+pub fn visit_array<'ast, V>(v: &mut V, node: &'ast Array)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for expr in node.iter() {
+        v.visit_expr(expr);
+    }
+}
+
+pub fn visit_object<'ast, V>(v: &mut V, node: &'ast Object)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for (key, value) in node.iter() {
+        v.visit_object_item(key, value);
+    }
+}
+
+pub fn visit_object_item<'ast, V>(v: &mut V, key: &'ast ObjectKey, value: &'ast ObjectValue)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_object_key(key);
+    v.visit_object_value(value);
+}
+
+pub fn visit_object_key<'ast, V>(v: &mut V, node: &'ast ObjectKey)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        ObjectKey::Ident(ident) => v.visit_ident(ident),
+        ObjectKey::Expression(expr) => v.visit_expr(expr),
+    }
+}
+
+pub fn visit_object_value<'ast, V>(v: &mut V, node: &'ast ObjectValue)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_expr(node.expr());
+}
+
+pub fn visit_parenthesis<'ast, V>(v: &mut V, node: &'ast Parenthesis)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_expr(node.inner());
+}
+
+pub fn visit_conditional<'ast, V>(v: &mut V, node: &'ast Conditional)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_expr(&node.cond_expr);
+    v.visit_expr(&node.true_expr);
+    v.visit_expr(&node.false_expr);
+}
+
+pub fn visit_unary_op<'ast, V>(v: &mut V, node: &'ast UnaryOp)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_unary_operator(&node.operator);
+    v.visit_expr(&node.expr);
+}
+
+pub fn visit_binary_op<'ast, V>(v: &mut V, node: &'ast BinaryOp)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_expr(&node.lhs_expr);
+    v.visit_binary_operator(&node.operator);
+    v.visit_expr(&node.rhs_expr);
+}
+
+pub fn visit_traversal<'ast, V>(v: &mut V, node: &'ast Traversal)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_expr(&node.expr);
+    for operator in &node.operators {
+        v.visit_traversal_operator(operator);
+    }
+}
+
+pub fn visit_traversal_operator<'ast, V>(v: &mut V, node: &'ast TraversalOperator)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        TraversalOperator::AttrSplat(splat) | TraversalOperator::FullSplat(splat) => {
+            v.visit_splat(splat);
+        }
+        TraversalOperator::GetAttr(ident) => v.visit_ident(ident),
+        TraversalOperator::Index(expr) => v.visit_expr(expr),
+        TraversalOperator::LegacyIndex(u) => v.visit_u64(u),
+    }
+}
+
+pub fn visit_func_call<'ast, V>(v: &mut V, node: &'ast FuncCall)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_ident(&node.ident);
+    v.visit_func_args(&node.args);
+}
+
+pub fn visit_func_args<'ast, V>(v: &mut V, node: &'ast FuncArgs)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for arg in node.iter() {
+        v.visit_expr(arg);
+    }
+}
+
+pub fn visit_for_expr<'ast, V>(v: &mut V, node: &'ast ForExpr)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_for_intro(&node.intro);
+    if let Some(key_expr) = &node.key_expr {
+        v.visit_expr(key_expr);
+    }
+    v.visit_expr(&node.value_expr);
+    if let Some(cond) = &node.cond {
+        v.visit_for_cond(cond);
+    }
+}
+
+pub fn visit_for_intro<'ast, V>(v: &mut V, node: &'ast ForIntro)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    if let Some(key_var) = &node.key_var {
+        v.visit_ident(key_var);
+    }
+    v.visit_ident(&node.value_var);
+    v.visit_expr(&node.collection_expr);
+}
+
+pub fn visit_for_cond<'ast, V>(v: &mut V, node: &'ast ForCond)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_expr(&node.expr);
+}
+
+pub fn visit_string_template<'ast, V>(v: &mut V, node: &'ast StringTemplate)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for element in node.iter() {
+        v.visit_element(element);
+    }
+}
+
+pub fn visit_heredoc_template<'ast, V>(v: &mut V, node: &'ast HeredocTemplate)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_template(&node.template);
+}
+
+pub fn visit_template<'ast, V>(v: &mut V, node: &'ast Template)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for element in node.iter() {
+        v.visit_element(element);
+    }
+}
+
+pub fn visit_element<'ast, V>(v: &mut V, node: &'ast Element)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        Element::Literal(literal) => v.visit_literal(literal),
+        Element::Interpolation(interpolation) => v.visit_interpolation(interpolation),
+        Element::Directive(directive) => v.visit_directive(directive),
+    }
+}
+
+pub fn visit_interpolation<'ast, V>(v: &mut V, node: &'ast Interpolation)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_expr(&node.expr);
+}
+
+pub fn visit_directive<'ast, V>(v: &mut V, node: &'ast Directive)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        Directive::If(if_directive) => v.visit_if_directive(if_directive),
+        Directive::For(for_directive) => v.visit_for_directive(for_directive),
+    }
+}
+
+pub fn visit_if_directive<'ast, V>(v: &mut V, node: &'ast IfDirective)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_if_template_expr(&node.if_expr);
+    if let Some(else_template_expr) = &node.else_expr {
+        v.visit_else_template_expr(else_template_expr);
+    }
+    v.visit_endif_template_expr(&node.endif_expr);
+}
+
+pub fn visit_for_directive<'ast, V>(v: &mut V, node: &'ast ForDirective)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_for_template_expr(&node.for_expr);
+    v.visit_endfor_template_expr(&node.endfor_expr);
+}
+
+pub fn visit_if_template_expr<'ast, V>(v: &mut V, node: &'ast IfTemplateExpr)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_expr(&node.cond_expr);
+    v.visit_template(&node.template);
+}
+
+pub fn visit_else_template_expr<'ast, V>(v: &mut V, node: &'ast ElseTemplateExpr)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    v.visit_template(&node.template);
+}
+
+pub fn visit_for_template_expr<'ast, V>(v: &mut V, node: &'ast ForTemplateExpr)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    if let Some(key_var) = &node.key_var {
+        v.visit_ident(key_var);
+    }
+    v.visit_ident(&node.value_var);
+    v.visit_template(&node.template);
+}

--- a/crates/hcl-edit/src/visit_mut.rs
+++ b/crates/hcl-edit/src/visit_mut.rs
@@ -1,0 +1,507 @@
+//! Mutable HCL language item traversal.
+//!
+//! Each method of the [`VisitMut`] trait is a hook that can be overridden to customize the
+//! behavior when mutating the corresponding type of language item. By default, every method
+//! recursively visits the substructure of the AST by invoking the right visitor method of each of
+//! its fields.
+//!
+//! The API is modeled after
+//! [`syn::visit_mut`](https://docs.rs/syn/latest/syn/visit_mut/index.html). For an alternative
+//! that works on shared borrows, see [`hcl_edit::visit`](crate::visit).
+//!
+//! # Examples
+//!
+//! Namespace all referenced variables with `var.`:
+//!
+//! ```
+//! # use std::error::Error;
+//! #
+//! # fn main() -> Result<(), Box<dyn Error>> {
+//! use hcl_edit::Ident;
+//! use hcl_edit::expr::{Expression, Traversal, TraversalOperator};
+//! use hcl_edit::repr::{Decorated, Decorate};
+//! use hcl_edit::structure::Body;
+//! use hcl_edit::visit_mut::{visit_expr_mut, VisitMut};
+//! use std::str::FromStr;
+//!
+//! struct VariableNamespacer {
+//!     namespace: Decorated<Ident>,
+//! }
+//!
+//! impl<'ast> VisitMut<'ast> for VariableNamespacer {
+//!     fn visit_expr_mut(&mut self, expr: &'ast mut Expression) {
+//!         if let Expression::Variable(var) = expr {
+//!             // Remove the decor and apply it to the new expression.
+//!             let decor = std::mem::take(var.decor_mut());
+//!
+//!             let namespace = Expression::Variable(self.namespace.clone());
+//!             let operators = vec![Decorated::new(TraversalOperator::GetAttr(var.clone()))];
+//!             let traversal = Traversal::new(namespace, operators);
+//!
+//!             *expr = Expression::from(traversal).decorated(decor);
+//!         } else {
+//!             // Recurse further down the AST.
+//!             visit_expr_mut(self, expr);
+//!         }
+//!     }
+//! }
+//!
+//! let input = r#"
+//!     // A service definition.
+//!     service {
+//!         fullname        = "${namespace}/${name}"
+//!         health_endpoint = "${base_url}/health"
+//!     }
+//! "#;
+//!
+//! let mut body = input.parse::<Body>()?;
+//!
+//! let mut visitor = VariableNamespacer {
+//!     namespace: Decorated::new(Ident::new("var")?),
+//! };
+//!
+//! visitor.visit_body_mut(&mut body);
+//!
+//! let expected = r#"
+//!     // A service definition.
+//!     service {
+//!         fullname        = "${var.namespace}/${var.name}"
+//!         health_endpoint = "${var.base_url}/health"
+//!     }
+//! "#;
+//!
+//! assert_eq!(body.to_string(), expected);
+//! #   Ok(())
+//! # }
+//! ```
+
+#![allow(missing_docs)]
+
+use crate::expr::{
+    Array, BinaryOp, BinaryOperator, Conditional, Expression, ForCond, ForExpr, ForIntro, FuncArgs,
+    FuncCall, Null, Object, ObjectKeyMut, ObjectValue, Parenthesis, Splat, Traversal,
+    TraversalOperator, UnaryOp, UnaryOperator,
+};
+use crate::repr::{Decorated, Formatted, Spanned};
+use crate::structure::{Attribute, Block, BlockBody, BlockLabel, Body, OnelineBody, Structure};
+use crate::template::{
+    Directive, Element, ElseTemplateExpr, EndforTemplateExpr, EndifTemplateExpr, ForDirective,
+    ForTemplateExpr, HeredocTemplate, IfDirective, IfTemplateExpr, Interpolation, StringTemplate,
+    Template,
+};
+use crate::{Ident, Number};
+
+macro_rules! empty_visit_mut_methods {
+    ($($name: ident => $t: ty),+ $(,)?) => {
+        $(
+            fn $name(&mut self, node: &'ast mut $t) {
+                let _ = node;
+            }
+        )*
+    };
+}
+
+macro_rules! visit_mut_methods {
+    ($($name: ident => $t: ty),+ $(,)?) => {
+        $(
+            fn $name(&mut self, node: &'ast mut $t) {
+                $name(self, node);
+            }
+        )*
+    };
+}
+
+/// Traversal to walk a mutable borrow of an HCL language item.
+///
+/// See the [module documentation](crate::visit_mut) for details.
+pub trait VisitMut<'ast> {
+    empty_visit_mut_methods! {
+        visit_ident_mut => Decorated<Ident>,
+        visit_null_mut => Decorated<Null>,
+        visit_bool_mut => Decorated<bool>,
+        visit_u64_mut => Decorated<u64>,
+        visit_number_mut => Formatted<Number>,
+        visit_string_mut => Decorated<String>,
+        visit_splat_mut => Decorated<Splat>,
+        visit_literal_mut => Spanned<String>,
+        visit_unary_operator_mut => Spanned<UnaryOperator>,
+        visit_binary_operator_mut => Spanned<BinaryOperator>,
+        visit_endif_template_expr_mut => EndifTemplateExpr,
+        visit_endfor_template_expr_mut => EndforTemplateExpr,
+    }
+
+    visit_mut_methods! {
+        visit_body_mut => Body,
+        visit_structure_mut => Structure,
+        visit_attr_mut => Attribute,
+        visit_block_mut => Block,
+        visit_block_label_mut => BlockLabel,
+        visit_block_body_mut => BlockBody,
+        visit_oneline_body_mut => OnelineBody,
+        visit_expr_mut => Expression,
+        visit_array_mut => Array,
+        visit_object_mut => Object,
+        visit_object_value_mut => ObjectValue,
+        visit_parenthesis_mut => Parenthesis,
+        visit_conditional_mut => Conditional,
+        visit_unary_op_mut => UnaryOp,
+        visit_binary_op_mut => BinaryOp,
+        visit_traversal_mut => Traversal,
+        visit_traversal_operator_mut => TraversalOperator,
+        visit_func_call_mut => FuncCall,
+        visit_func_args_mut => FuncArgs,
+        visit_for_expr_mut => ForExpr,
+        visit_for_intro_mut => ForIntro,
+        visit_for_cond_mut => ForCond,
+        visit_string_template_mut => StringTemplate,
+        visit_heredoc_template_mut => HeredocTemplate,
+        visit_template_mut => Template,
+        visit_element_mut => Element,
+        visit_interpolation_mut => Interpolation,
+        visit_directive_mut => Directive,
+        visit_if_directive_mut => IfDirective,
+        visit_for_directive_mut => ForDirective,
+        visit_if_template_expr_mut => IfTemplateExpr,
+        visit_else_template_expr_mut => ElseTemplateExpr,
+        visit_for_template_expr_mut => ForTemplateExpr,
+    }
+
+    fn visit_object_key_mut(&mut self, node: ObjectKeyMut<'ast>) {
+        let _ = node;
+    }
+
+    fn visit_object_item_mut(&mut self, key: ObjectKeyMut<'ast>, value: &'ast mut ObjectValue) {
+        visit_object_item_mut(self, key, value);
+    }
+}
+
+pub fn visit_body_mut<'ast, V>(v: &mut V, node: &'ast mut Body)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    for structure in node.iter_mut() {
+        v.visit_structure_mut(structure);
+    }
+}
+
+pub fn visit_structure_mut<'ast, V>(v: &mut V, node: &'ast mut Structure)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    match node {
+        Structure::Attribute(attr) => v.visit_attr_mut(attr),
+        Structure::Block(block) => v.visit_block_mut(block),
+    }
+}
+
+pub fn visit_attr_mut<'ast, V>(v: &mut V, node: &'ast mut Attribute)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_ident_mut(&mut node.key);
+    v.visit_expr_mut(&mut node.value);
+}
+
+pub fn visit_block_mut<'ast, V>(v: &mut V, node: &'ast mut Block)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_ident_mut(&mut node.ident);
+    for label in &mut node.labels {
+        v.visit_block_label_mut(label);
+    }
+    v.visit_block_body_mut(&mut node.body);
+}
+
+pub fn visit_block_label_mut<'ast, V>(v: &mut V, node: &'ast mut BlockLabel)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    match node {
+        BlockLabel::String(string) => v.visit_string_mut(string),
+        BlockLabel::Ident(ident) => v.visit_ident_mut(ident),
+    }
+}
+
+pub fn visit_block_body_mut<'ast, V>(v: &mut V, node: &'ast mut BlockBody)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    match node {
+        BlockBody::Oneline(oneline) => v.visit_oneline_body_mut(oneline),
+        BlockBody::Multiline(body) => v.visit_body_mut(body),
+    }
+}
+
+pub fn visit_oneline_body_mut<'ast, V>(v: &mut V, node: &'ast mut OnelineBody)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    if let Some(attr) = node.as_attribute_mut() {
+        v.visit_attr_mut(attr);
+    }
+}
+
+pub fn visit_expr_mut<'ast, V>(v: &mut V, node: &'ast mut Expression)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    match node {
+        Expression::Null(null) => v.visit_null_mut(null),
+        Expression::Bool(b) => v.visit_bool_mut(b),
+        Expression::Number(number) => v.visit_number_mut(number),
+        Expression::String(string) => v.visit_string_mut(string),
+        Expression::Array(array) => v.visit_array_mut(array),
+        Expression::Object(object) => v.visit_object_mut(object),
+        Expression::Template(template) => v.visit_string_template_mut(template),
+        Expression::HeredocTemplate(template) => v.visit_heredoc_template_mut(template),
+        Expression::Parenthesis(parens) => v.visit_parenthesis_mut(parens),
+        Expression::Variable(var) => v.visit_ident_mut(var),
+        Expression::ForExpr(for_expr) => v.visit_for_expr_mut(for_expr),
+        Expression::Conditional(conditional) => v.visit_conditional_mut(conditional),
+        Expression::FuncCall(func_call) => v.visit_func_call_mut(func_call),
+        Expression::UnaryOp(unary_op) => v.visit_unary_op_mut(unary_op),
+        Expression::BinaryOp(binary_op) => v.visit_binary_op_mut(binary_op),
+        Expression::Traversal(traversal) => v.visit_traversal_mut(traversal),
+    }
+}
+
+pub fn visit_array_mut<'ast, V>(v: &mut V, node: &'ast mut Array)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    for expr in node.iter_mut() {
+        v.visit_expr_mut(expr);
+    }
+}
+
+pub fn visit_object_mut<'ast, V>(v: &mut V, node: &'ast mut Object)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    for (key, value) in node.iter_mut() {
+        v.visit_object_item_mut(key, value);
+    }
+}
+
+pub fn visit_object_item_mut<'ast, V>(
+    v: &mut V,
+    key: ObjectKeyMut<'ast>,
+    value: &'ast mut ObjectValue,
+) where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_object_key_mut(key);
+    v.visit_object_value_mut(value);
+}
+
+pub fn visit_object_value_mut<'ast, V>(v: &mut V, node: &'ast mut ObjectValue)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_expr_mut(node.expr_mut());
+}
+
+pub fn visit_parenthesis_mut<'ast, V>(v: &mut V, node: &'ast mut Parenthesis)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_expr_mut(node.inner_mut());
+}
+
+pub fn visit_conditional_mut<'ast, V>(v: &mut V, node: &'ast mut Conditional)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_expr_mut(&mut node.cond_expr);
+    v.visit_expr_mut(&mut node.true_expr);
+    v.visit_expr_mut(&mut node.false_expr);
+}
+
+pub fn visit_unary_op_mut<'ast, V>(v: &mut V, node: &'ast mut UnaryOp)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_unary_operator_mut(&mut node.operator);
+    v.visit_expr_mut(&mut node.expr);
+}
+
+pub fn visit_binary_op_mut<'ast, V>(v: &mut V, node: &'ast mut BinaryOp)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_expr_mut(&mut node.lhs_expr);
+    v.visit_binary_operator_mut(&mut node.operator);
+    v.visit_expr_mut(&mut node.rhs_expr);
+}
+
+pub fn visit_traversal_mut<'ast, V>(v: &mut V, node: &'ast mut Traversal)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_expr_mut(&mut node.expr);
+    for operator in &mut node.operators {
+        v.visit_traversal_operator_mut(operator);
+    }
+}
+
+pub fn visit_traversal_operator_mut<'ast, V>(v: &mut V, node: &'ast mut TraversalOperator)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    match node {
+        TraversalOperator::AttrSplat(splat) | TraversalOperator::FullSplat(splat) => {
+            v.visit_splat_mut(splat);
+        }
+        TraversalOperator::GetAttr(ident) => v.visit_ident_mut(ident),
+        TraversalOperator::Index(expr) => v.visit_expr_mut(expr),
+        TraversalOperator::LegacyIndex(u) => v.visit_u64_mut(u),
+    }
+}
+
+pub fn visit_func_call_mut<'ast, V>(v: &mut V, node: &'ast mut FuncCall)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_ident_mut(&mut node.ident);
+    v.visit_func_args_mut(&mut node.args);
+}
+
+pub fn visit_func_args_mut<'ast, V>(v: &mut V, node: &'ast mut FuncArgs)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    for arg in node.iter_mut() {
+        v.visit_expr_mut(arg);
+    }
+}
+
+pub fn visit_for_expr_mut<'ast, V>(v: &mut V, node: &'ast mut ForExpr)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_for_intro_mut(&mut node.intro);
+    if let Some(key_expr) = &mut node.key_expr {
+        v.visit_expr_mut(key_expr);
+    }
+    v.visit_expr_mut(&mut node.value_expr);
+    if let Some(cond) = &mut node.cond {
+        v.visit_for_cond_mut(cond);
+    }
+}
+
+pub fn visit_for_intro_mut<'ast, V>(v: &mut V, node: &'ast mut ForIntro)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    if let Some(key_var) = &mut node.key_var {
+        v.visit_ident_mut(key_var);
+    }
+    v.visit_ident_mut(&mut node.value_var);
+    v.visit_expr_mut(&mut node.collection_expr);
+}
+
+pub fn visit_for_cond_mut<'ast, V>(v: &mut V, node: &'ast mut ForCond)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_expr_mut(&mut node.expr);
+}
+
+pub fn visit_string_template_mut<'ast, V>(v: &mut V, node: &'ast mut StringTemplate)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    for element in node.iter_mut() {
+        v.visit_element_mut(element);
+    }
+}
+
+pub fn visit_heredoc_template_mut<'ast, V>(v: &mut V, node: &'ast mut HeredocTemplate)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_template_mut(&mut node.template);
+}
+
+pub fn visit_template_mut<'ast, V>(v: &mut V, node: &'ast mut Template)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    for element in node.iter_mut() {
+        v.visit_element_mut(element);
+    }
+}
+
+pub fn visit_element_mut<'ast, V>(v: &mut V, node: &'ast mut Element)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    match node {
+        Element::Literal(literal) => v.visit_literal_mut(literal),
+        Element::Interpolation(interpolation) => v.visit_interpolation_mut(interpolation),
+        Element::Directive(directive) => v.visit_directive_mut(directive),
+    }
+}
+
+pub fn visit_interpolation_mut<'ast, V>(v: &mut V, node: &'ast mut Interpolation)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_expr_mut(&mut node.expr);
+}
+
+pub fn visit_directive_mut<'ast, V>(v: &mut V, node: &'ast mut Directive)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    match node {
+        Directive::If(if_directive) => v.visit_if_directive_mut(if_directive),
+        Directive::For(for_directive) => v.visit_for_directive_mut(for_directive),
+    }
+}
+
+pub fn visit_if_directive_mut<'ast, V>(v: &mut V, node: &'ast mut IfDirective)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_if_template_expr_mut(&mut node.if_expr);
+    if let Some(else_template_expr) = &mut node.else_expr {
+        v.visit_else_template_expr_mut(else_template_expr);
+    }
+    v.visit_endif_template_expr_mut(&mut node.endif_expr);
+}
+
+pub fn visit_for_directive_mut<'ast, V>(v: &mut V, node: &'ast mut ForDirective)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_for_template_expr_mut(&mut node.for_expr);
+    v.visit_endfor_template_expr_mut(&mut node.endfor_expr);
+}
+
+pub fn visit_if_template_expr_mut<'ast, V>(v: &mut V, node: &'ast mut IfTemplateExpr)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_expr_mut(&mut node.cond_expr);
+    v.visit_template_mut(&mut node.template);
+}
+
+pub fn visit_else_template_expr_mut<'ast, V>(v: &mut V, node: &'ast mut ElseTemplateExpr)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    v.visit_template_mut(&mut node.template);
+}
+
+pub fn visit_for_template_expr_mut<'ast, V>(v: &mut V, node: &'ast mut ForTemplateExpr)
+where
+    V: VisitMut<'ast> + ?Sized,
+{
+    if let Some(key_var) = &mut node.key_var {
+        v.visit_ident_mut(key_var);
+    }
+    v.visit_ident_mut(&mut node.value_var);
+    v.visit_template_mut(&mut node.template);
+}


### PR DESCRIPTION
This uses the same design as the `syn` and `toml_edit` crates.