### PR TITLE
fix(parser): handle `/` ambiguity in expression parser

### DIFF
--- a/crates/hcl-edit/src/parser/expr.rs
+++ b/crates/hcl-edit/src/parser/expr.rs
@@ -54,6 +54,8 @@ pub(super) fn expr_inner<'i, 's>(
                     // argument of a function call, do not mistakenly parse it as a traversal
                     // operator.
                     b".." => return Ok((input, ())),
+                    // This is a comment start, do not mistakenly parse a binary division operator.
+                    b"//" | b"/*" => return Ok((input, ())),
                     // Traversal operator.
                     //
                     // Note: after the traversal is consumed, the loop is entered again to consume

--- a/crates/hcl-edit/src/parser/tests.rs
+++ b/crates/hcl-edit/src/parser/tests.rs
@@ -84,6 +84,8 @@ fn roundtrip_body() {
                   heredoc
                 EOT
         "#},
+        "ami = \"ami-5f6495430e7781fe5\" // Ubuntu 20.04 LTS\n",
+        "ami = \"ami-5f6495430e7781fe5\" /* Ubuntu 20.04 LTS */\n",
     ];
 
     let tests = testdata::load().unwrap();


### PR DESCRIPTION
Fixes #188