### PR TITLE
feat!: add useful collection methods

### DIFF
--- a/crates/hcl-edit/src/expr/func_call.rs
+++ b/crates/hcl-edit/src/expr/func_call.rs
@@ -1,13 +1,14 @@
-#![allow(missing_docs)]
-
 use crate::expr::{Expression, IntoIter, Iter, IterMut};
 use crate::repr::{Decor, Decorate, Decorated, SetSpan, Span};
 use crate::{Ident, RawString};
 use std::ops::Range;
 
+/// Type representing a function call.
 #[derive(Debug, Clone, Eq)]
 pub struct FuncCall {
+    /// The function identifier (or name).
     pub ident: Decorated<Ident>,
+    /// The arguments between the function call's `(` and `)` argument delimiters.
     pub args: FuncArgs,
 
     decor: Decor,
@@ -15,6 +16,7 @@ pub struct FuncCall {
 }
 
 impl FuncCall {
+    /// Create a new `FuncCall` from an identifier and arguments.
     pub fn new(ident: Decorated<Ident>, args: FuncArgs) -> FuncCall {
         FuncCall {
             ident,
@@ -37,6 +39,9 @@ impl PartialEq for FuncCall {
     }
 }
 
+/// Type representing the arguments of a function call.
+///
+/// In the HCL grammar, function arguments are delimited by `(` and `)`.
 #[derive(Debug, Clone, Eq, Default)]
 pub struct FuncArgs {
     args: Vec<Expression>,
@@ -48,53 +53,139 @@ pub struct FuncArgs {
 }
 
 impl FuncArgs {
-    pub fn new(args: Vec<Expression>) -> FuncArgs {
+    /// Constructs new, empty `FuncArgs`.
+    #[inline]
+    pub fn new() -> Self {
+        FuncArgs::default()
+    }
+
+    /// Constructs new, empty `FuncArgs` with at least the specified capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
         FuncArgs {
-            args,
-            expand_final: false,
-            trailing: RawString::default(),
-            trailing_comma: false,
-            decor: Decor::default(),
-            span: None,
+            args: Vec::with_capacity(capacity),
+            ..Default::default()
         }
     }
 
+    /// Returns `true` if the function arguments are empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.args.is_empty()
     }
 
+    /// Returns the number of function arguments, also referred to as its 'length'.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.args.len()
+    }
+
+    /// Clears the function arguments.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.args.clear();
+    }
+
+    /// Returns a reference to the argument at the given index, or `None` if the index is out of
+    /// bounds.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&Expression> {
+        self.args.get(index)
+    }
+
+    /// Returns a mutable reference to the argument at the given index, or `None` if the index is
+    /// out of bounds.
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Expression> {
+        self.args.get_mut(index)
+    }
+
+    /// Inserts an argument at position `index`, shifting all arguments after it to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    #[inline]
+    pub fn insert(&mut self, index: usize, arg: impl Into<Expression>) {
+        self.args.insert(index, arg.into());
+    }
+
+    /// Removes the last argument and returns it, or [`None`] if it is empty.
+    #[inline]
+    pub fn pop(&mut self) -> Option<Expression> {
+        self.args.pop()
+    }
+
+    /// Appends an argument.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    #[inline]
+    pub fn push(&mut self, arg: impl Into<Expression>) {
+        self.args.push(arg.into());
+    }
+
+    /// Removes and returns the argument at position `index`, shifting all arguments after it to
+    /// the left.
+    ///
+    /// Like `Vec::remove`, the argument is removed by shifting all of the arguments that follow
+    /// it, preserving their relative order. **This perturbs the index of all of those elements!**
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> Expression {
+        self.args.remove(index)
+    }
+
     /// An iterator visiting all values in insertion order. The iterator element type is `&'a
     /// Expression`.
+    #[inline]
     pub fn iter(&self) -> Iter<'_> {
         Box::new(self.args.iter())
     }
 
     /// An iterator visiting all values in insertion order, with mutable references to the values.
     /// The iterator element type is `&'a mut Expression`.
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<'_> {
         Box::new(self.args.iter_mut())
     }
 
+    /// Returns `true` if the final argument is a `...` list expansion.
+    #[inline]
     pub fn expand_final(&self) -> bool {
         self.expand_final
     }
 
+    /// Set whether the final argument should be a `...` list expansion.
+    #[inline]
     pub fn set_expand_final(&mut self, yes: bool) {
         self.expand_final = yes;
     }
 
+    /// Return a reference to raw trailing decor before the function argument's closing `)`.
+    #[inline]
     pub fn trailing(&self) -> &RawString {
         &self.trailing
     }
 
+    /// Set the raw trailing decor before the function argument's closing `)`.
+    #[inline]
     pub fn set_trailing(&mut self, trailing: impl Into<RawString>) {
         self.trailing = trailing.into();
     }
 
+    /// Returns `true` if the function arguments use a trailing comma.
+    #[inline]
     pub fn trailing_comma(&self) -> bool {
         self.trailing_comma
     }
 
+    /// Set whether the function arguments will use a trailing comma.
+    #[inline]
     pub fn set_trailing_comma(&mut self, yes: bool) {
         self.trailing_comma = yes;
     }
@@ -117,6 +208,15 @@ impl PartialEq for FuncArgs {
     }
 }
 
+impl From<Vec<Expression>> for FuncArgs {
+    fn from(args: Vec<Expression>) -> Self {
+        FuncArgs {
+            args,
+            ..Default::default()
+        }
+    }
+}
+
 impl<T> Extend<T> for FuncArgs
 where
     T: Into<Expression>,
@@ -125,9 +225,14 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        for v in iterable {
-            self.args.push(v.into());
-        }
+        let iter = iterable.into_iter();
+        let reserve = if self.is_empty() {
+            iter.size_hint().0
+        } else {
+            (iter.size_hint().0 + 1) / 2
+        };
+        self.args.reserve(reserve);
+        iter.for_each(|v| self.push(v));
     }
 }
 
@@ -135,11 +240,15 @@ impl<T> FromIterator<T> for FuncArgs
 where
     T: Into<Expression>,
 {
-    fn from_iter<I>(iter: I) -> Self
+    fn from_iter<I>(iterable: I) -> Self
     where
         I: IntoIterator<Item = T>,
     {
-        FuncArgs::new(iter.into_iter().map(Into::into).collect())
+        let iter = iterable.into_iter();
+        let lower = iter.size_hint().0;
+        let mut func_args = FuncArgs::with_capacity(lower);
+        func_args.extend(iter);
+        func_args
     }
 }
 

--- a/crates/hcl-edit/src/parser/expr.rs
+++ b/crates/hcl-edit/src/parser/expr.rs
@@ -637,7 +637,8 @@ fn func_args(input: Input) -> IResult<Input, FuncArgs> {
         (opt((args, opt(trailer))), raw_string(ws)).map(|(args, trailing)| {
             let mut args = match args {
                 Some((args, Some(trailer))) => {
-                    let mut args = FuncArgs::new(args);
+                    let args: Vec<_> = args;
+                    let mut args = FuncArgs::from(args);
                     if let Trailer::Ellipsis = trailer {
                         args.set_expand_final(true);
                     } else {
@@ -645,7 +646,7 @@ fn func_args(input: Input) -> IResult<Input, FuncArgs> {
                     }
                     args
                 }
-                Some((args, None)) => FuncArgs::new(args),
+                Some((args, None)) => FuncArgs::from(args),
                 None => FuncArgs::default(),
             };
 

--- a/crates/hcl-edit/src/structure/mod.rs
+++ b/crates/hcl-edit/src/structure/mod.rs
@@ -43,26 +43,104 @@ pub struct Body {
 }
 
 impl Body {
-    pub fn new() -> Body {
+    /// Constructs a new, empty `Body`.
+    #[inline]
+    pub fn new() -> Self {
         Body::default()
     }
 
+    /// Constructs a new, empty `Body` with at least the specified capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Body {
+            structures: Vec::with_capacity(capacity),
+            ..Default::default()
+        }
+    }
+
+    /// Returns `true` if the body contains no structures.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.structures.is_empty()
     }
 
+    /// Returns the number of structures in the body, also referred to as its 'length'.
+    #[inline]
     pub fn len(&self) -> usize {
         self.structures.len()
     }
 
+    /// Clears the body, removing all structures.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.structures.clear();
+    }
+
+    /// Returns a reference to the structure at the given index, or `None` if the index is out of
+    /// bounds.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&Structure> {
+        self.structures.get(index)
+    }
+
+    /// Returns a mutable reference to the structure at the given index, or `None` if the index is
+    /// out of bounds.
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Structure> {
+        self.structures.get_mut(index)
+    }
+
+    /// Inserts a structure at position `index` within the body, shifting all structures after it
+    /// to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    #[inline]
+    pub fn insert(&mut self, index: usize, structure: impl Into<Structure>) {
+        self.structures.insert(index, structure.into());
+    }
+
+    /// Appends a structure to the back of the body.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    #[inline]
+    pub fn push(&mut self, structure: impl Into<Structure>) {
+        self.structures.push(structure.into());
+    }
+
+    /// Removes the last structure from the body and returns it, or [`None`] if it is empty.
+    #[inline]
+    pub fn pop(&mut self) -> Option<Structure> {
+        self.structures.pop()
+    }
+
+    /// Removes and returns the structure at position `index` within the body, shifting all
+    /// elements after it to the left.
+    ///
+    /// Like `Vec::remove`, the structure is removed by shifting all of the structures that follow
+    /// it, preserving their relative order. **This perturbs the index of all of those elements!**
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> Structure {
+        self.structures.remove(index)
+    }
+
     /// An iterator visiting all body structures in insertion order. The iterator element type is
     /// `&'a Structure`.
+    #[inline]
     pub fn iter(&self) -> Iter<'_> {
         Box::new(self.structures.iter())
     }
 
     /// An iterator visiting all body structures in insertion order, with mutable references to the
     /// values. The iterator element type is `&'a mut Structure`.
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<'_> {
         Box::new(self.structures.iter_mut())
     }
@@ -113,9 +191,14 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        for v in iterable {
-            self.structures.push(v.into());
-        }
+        let iter = iterable.into_iter();
+        let reserve = if self.is_empty() {
+            iter.size_hint().0
+        } else {
+            (iter.size_hint().0 + 1) / 2
+        };
+        self.structures.reserve(reserve);
+        iter.for_each(|v| self.push(v));
     }
 }
 
@@ -123,11 +206,15 @@ impl<T> FromIterator<T> for Body
 where
     T: Into<Structure>,
 {
-    fn from_iter<I>(iter: I) -> Self
+    fn from_iter<I>(iterable: I) -> Self
     where
         I: IntoIterator<Item = T>,
     {
-        iter.into_iter().map(Into::into).collect::<Vec<_>>().into()
+        let iter = iterable.into_iter();
+        let lower = iter.size_hint().0;
+        let mut body = Body::with_capacity(lower);
+        body.extend(iter);
+        body
     }
 }
 
@@ -300,6 +387,7 @@ pub enum BlockBody {
 }
 
 impl BlockBody {
+    /// Returns `true` if the block body contains no structures.
     pub fn is_empty(&self) -> bool {
         match self {
             BlockBody::Multiline(body) => body.is_empty(),
@@ -307,6 +395,7 @@ impl BlockBody {
         }
     }
 
+    /// Returns the number of structures in the block body, also referred to as its 'length'.
     pub fn len(&self) -> usize {
         match self {
             BlockBody::Multiline(body) => body.len(),

--- a/crates/hcl-edit/src/template/mod.rs
+++ b/crates/hcl-edit/src/template/mod.rs
@@ -48,18 +48,104 @@ pub struct StringTemplate {
 }
 
 impl StringTemplate {
-    pub fn new() -> StringTemplate {
+    /// Constructs a new, empty `StringTemplate`.
+    #[inline]
+    pub fn new() -> Self {
         StringTemplate::default()
+    }
+
+    /// Constructs a new, empty `StringTemplate` with at least the specified capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        StringTemplate {
+            elements: Vec::with_capacity(capacity),
+            ..Default::default()
+        }
+    }
+
+    /// Returns `true` if the template contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Returns the number of elements in the template, also referred to as its 'length'.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Clears the template, removing all elements.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.elements.clear();
+    }
+
+    /// Returns a reference to the element at the given index, or `None` if the index is out of
+    /// bounds.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&Element> {
+        self.elements.get(index)
+    }
+
+    /// Returns a mutable reference to the element at the given index, or `None` if the index is
+    /// out of bounds.
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Element> {
+        self.elements.get_mut(index)
+    }
+
+    /// Inserts an element at position `index` within the template, shifting all elements after it
+    /// to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    #[inline]
+    pub fn insert(&mut self, index: usize, element: impl Into<Element>) {
+        self.elements.insert(index, element.into());
+    }
+
+    /// Appends an element to the back of the template.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    #[inline]
+    pub fn push(&mut self, element: impl Into<Element>) {
+        self.elements.push(element.into());
+    }
+
+    /// Removes the last element from the template and returns it, or [`None`] if it is empty.
+    #[inline]
+    pub fn pop(&mut self) -> Option<Element> {
+        self.elements.pop()
+    }
+
+    /// Removes and returns the element at position `index` within the template, shifting all
+    /// elements after it to the left.
+    ///
+    /// Like `Vec::remove`, the element is removed by shifting all of the elements that follow it,
+    /// preserving their relative order. **This perturbs the index of all of those elements!**
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> Element {
+        self.elements.remove(index)
     }
 
     /// An iterator visiting all template elements in insertion order. The iterator element type
     /// is `&'a Element`.
+    #[inline]
     pub fn iter(&self) -> Iter<'_> {
         Box::new(self.elements.iter())
     }
 
     /// An iterator visiting all template elements in insertion order, with mutable references to
     /// the values. The iterator element type is `&'a mut Element`.
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<'_> {
         Box::new(self.elements.iter_mut())
     }
@@ -96,9 +182,14 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        for v in iterable {
-            self.elements.push(v.into());
-        }
+        let iter = iterable.into_iter();
+        let reserve = if self.is_empty() {
+            iter.size_hint().0
+        } else {
+            (iter.size_hint().0 + 1) / 2
+        };
+        self.elements.reserve(reserve);
+        iter.for_each(|v| self.push(v));
     }
 }
 
@@ -106,11 +197,15 @@ impl<T> FromIterator<T> for StringTemplate
 where
     T: Into<Element>,
 {
-    fn from_iter<I>(iter: I) -> Self
+    fn from_iter<I>(iterable: I) -> Self
     where
         I: IntoIterator<Item = T>,
     {
-        iter.into_iter().map(Into::into).collect::<Vec<_>>().into()
+        let iter = iterable.into_iter();
+        let lower = iter.size_hint().0;
+        let mut template = StringTemplate::with_capacity(lower);
+        template.extend(iter);
+        template
     }
 }
 
@@ -234,18 +329,104 @@ pub struct Template {
 }
 
 impl Template {
-    pub fn new() -> Template {
+    /// Constructs a new, empty `Template`.
+    #[inline]
+    pub fn new() -> Self {
         Template::default()
+    }
+
+    /// Constructs a new, empty `Template` with at least the specified capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Template {
+            elements: Vec::with_capacity(capacity),
+            ..Default::default()
+        }
+    }
+
+    /// Returns `true` if the template contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Returns the number of elements in the template, also referred to as its 'length'.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Clears the template, removing all elements.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.elements.clear();
+    }
+
+    /// Returns a reference to the element at the given index, or `None` if the index is out of
+    /// bounds.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&Element> {
+        self.elements.get(index)
+    }
+
+    /// Returns a mutable reference to the element at the given index, or `None` if the index is
+    /// out of bounds.
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Element> {
+        self.elements.get_mut(index)
+    }
+
+    /// Inserts an element at position `index` within the template, shifting all elements after it
+    /// to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    #[inline]
+    pub fn insert(&mut self, index: usize, element: impl Into<Element>) {
+        self.elements.insert(index, element.into());
+    }
+
+    /// Appends an element to the back of the template.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    #[inline]
+    pub fn push(&mut self, element: impl Into<Element>) {
+        self.elements.push(element.into());
+    }
+
+    /// Removes the last element from the template and returns it, or [`None`] if it is empty.
+    #[inline]
+    pub fn pop(&mut self) -> Option<Element> {
+        self.elements.pop()
+    }
+
+    /// Removes and returns the element at position `index` within the template, shifting all
+    /// elements after it to the left.
+    ///
+    /// Like `Vec::remove`, the element is removed by shifting all of the elements that follow it,
+    /// preserving their relative order. **This perturbs the index of all of those elements!**
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> Element {
+        self.elements.remove(index)
     }
 
     /// An iterator visiting all template elements in insertion order. The iterator element type
     /// is `&'a Element`.
+    #[inline]
     pub fn iter(&self) -> Iter<'_> {
         Box::new(self.elements.iter())
     }
 
     /// An iterator visiting all template elements in insertion order, with mutable references to
     /// the values. The iterator element type is `&'a mut Element`.
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<'_> {
         Box::new(self.elements.iter_mut())
     }
@@ -282,7 +463,7 @@ impl From<Vec<Element>> for Template {
     fn from(elements: Vec<Element>) -> Self {
         Template {
             elements,
-            span: None,
+            ..Default::default()
         }
     }
 }
@@ -295,9 +476,14 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        for v in iterable {
-            self.elements.push(v.into());
-        }
+        let iter = iterable.into_iter();
+        let reserve = if self.is_empty() {
+            iter.size_hint().0
+        } else {
+            (iter.size_hint().0 + 1) / 2
+        };
+        self.elements.reserve(reserve);
+        iter.for_each(|v| self.push(v));
     }
 }
 
@@ -305,11 +491,15 @@ impl<T> FromIterator<T> for Template
 where
     T: Into<Element>,
 {
-    fn from_iter<I>(iter: I) -> Self
+    fn from_iter<I>(iterable: I) -> Self
     where
         I: IntoIterator<Item = T>,
     {
-        iter.into_iter().map(Into::into).collect::<Vec<_>>().into()
+        let iter = iterable.into_iter();
+        let lower = iter.size_hint().0;
+        let mut template = Template::with_capacity(lower);
+        template.extend(iter);
+        template
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: `FuncArgs::new` does not take any arguments anymore to align with constructors of other collection types. Use `FuncArgs::from(args)`, `FuncArgs::from_iter(args)` and `FuncArgs::push(arg)` instead.