### PR TITLE
feat(ident): add `Ident::try_new`

### DIFF
--- a/crates/hcl-edit/src/structure/mod.rs
+++ b/crates/hcl-edit/src/structure/mod.rs
@@ -580,7 +580,7 @@ impl BlockBody {
     /// use hcl_edit::structure::{Attribute, BlockBody, OnelineBody, Structure};
     /// use hcl_edit::Ident;
     ///
-    /// let attr = Attribute::new(Ident::new("key")?.into(), "value".into());
+    /// let attr = Attribute::new(Ident::try_new("key")?.into(), "value".into());
     /// let oneline = OnelineBody::from(attr.clone());
     /// let mut block_body = BlockBody::from(oneline);
     ///
@@ -617,7 +617,7 @@ impl BlockBody {
     /// use hcl_edit::structure::{Attribute, BlockBody, OnelineBody, Structure};
     /// use hcl_edit::Ident;
     ///
-    /// let attr = Attribute::new(Ident::new("key")?.into(), "value".into());
+    /// let attr = Attribute::new(Ident::try_new("key")?.into(), "value".into());
     /// let oneline = OnelineBody::from(attr.clone());
     /// let block_body = BlockBody::from(oneline);
     ///
@@ -683,7 +683,7 @@ impl BlockBody {
     /// use hcl_edit::structure::{Attribute, BlockBody, Body, Structure};
     /// use hcl_edit::Ident;
     ///
-    /// let attr = Attribute::new(Ident::new("key")?.into(), "value".into());
+    /// let attr = Attribute::new(Ident::try_new("key")?.into(), "value".into());
     /// let mut multiline = Body::new();
     /// multiline.push(attr.clone());
     ///
@@ -739,7 +739,7 @@ impl BlockBody {
     /// use hcl_edit::structure::{Attribute, BlockBody, Body, Structure};
     /// use hcl_edit::Ident;
     ///
-    /// let attr = Attribute::new(Ident::new("key")?.into(), "value".into());
+    /// let attr = Attribute::new(Ident::try_new("key")?.into(), "value".into());
     /// let mut multiline = Body::new();
     /// multiline.push(attr.clone());
     ///

--- a/crates/hcl-edit/src/visit_mut.rs
+++ b/crates/hcl-edit/src/visit_mut.rs
@@ -57,7 +57,7 @@
 //! let mut body = input.parse::<Body>()?;
 //!
 //! let mut visitor = VariableNamespacer {
-//!     namespace: Decorated::new(Ident::new("var")?),
+//!     namespace: Decorated::new(Ident::try_new("var")?),
 //! };
 //!
 //! visitor.visit_body_mut(&mut body);

--- a/crates/hcl-primitives/src/ident.rs
+++ b/crates/hcl-primitives/src/ident.rs
@@ -37,6 +37,33 @@ impl Ident {
     where
         T: Into<InternalString>,
     {
+        Ident::try_new(ident)
+    }
+
+    /// Create a new `Ident` after validating that it only contains characters that are allowed in
+    /// HCL identifiers.
+    ///
+    /// See [`Ident::new_sanitized`][Ident::new_sanitized] for an infallible alternative to this
+    /// function.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use hcl_primitives::Ident;
+    /// assert!(Ident::try_new("some_ident").is_ok());
+    /// assert!(Ident::try_new("").is_err());
+    /// assert!(Ident::try_new("1two3").is_err());
+    /// assert!(Ident::try_new("with whitespace").is_err());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// If `ident` contains characters that are not allowed in HCL identifiers or if it is empty an
+    /// error will be returned.
+    pub fn try_new<T>(ident: T) -> Result<Ident, Error>
+    where
+        T: Into<InternalString>,
+    {
         let ident = ident.into();
 
         if !is_ident(&ident) {
@@ -132,7 +159,7 @@ impl TryFrom<InternalString> for Ident {
 
     #[inline]
     fn try_from(s: InternalString) -> Result<Self, Self::Error> {
-        Ident::new(s)
+        Ident::try_new(s)
     }
 }
 
@@ -141,7 +168,7 @@ impl TryFrom<String> for Ident {
 
     #[inline]
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        Ident::new(s)
+        Ident::try_new(s)
     }
 }
 
@@ -150,7 +177,7 @@ impl TryFrom<&str> for Ident {
 
     #[inline]
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        Ident::new(s)
+        Ident::try_new(s)
     }
 }
 
@@ -159,7 +186,7 @@ impl<'a> TryFrom<Cow<'a, str>> for Ident {
 
     #[inline]
     fn try_from(s: Cow<'a, str>) -> Result<Self, Self::Error> {
-        Ident::new(s)
+        Ident::try_new(s)
     }
 }
 
@@ -168,7 +195,7 @@ impl FromStr for Ident {
 
     #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ident::new(s)
+        Ident::try_new(s)
     }
 }
 
@@ -240,7 +267,7 @@ impl<'de> serde::Deserialize<'de> for Ident {
         D: serde::Deserializer<'de>,
     {
         let string = InternalString::deserialize(deserializer)?;
-        Ident::new(string).map_err(serde::de::Error::custom)
+        Ident::try_new(string).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/hcl-rs/src/ident.rs
+++ b/crates/hcl-rs/src/ident.rs
@@ -40,7 +40,7 @@ impl Identifier {
     where
         T: Into<InternalString>,
     {
-        Ident::new(ident).map(Identifier).map_err(Error::new)
+        Ident::try_new(ident).map(Identifier).map_err(Error::new)
     }
 
     /// Create a new `Identifier` after sanitizing the input if necessary.


### PR DESCRIPTION
In a followup change `Ident::new` will be changed panic when provided with an invalid identifier. The return type will be changed from `Result<Ident, Error>` to `Ident`.