### PR TITLE
revert(template): dereference `StringTemplate` to `Template`

### DIFF
--- a/crates/hcl-edit/src/template/mod.rs
+++ b/crates/hcl-edit/src/template/mod.rs
@@ -6,7 +6,7 @@ use crate::repr::{Decor, Decorate, Decorated, SetSpan, Span, Spanned};
 use crate::util::{dedent_by, min_leading_whitespace};
 use crate::{parser, Ident, RawString};
 use std::fmt;
-use std::ops::{self, Range};
+use std::ops::Range;
 use std::str::FromStr;
 
 // Re-exported for convenience.
@@ -44,8 +44,9 @@ pub type IterMut<'a> = Box<dyn Iterator<Item = &'a mut Element> + 'a>;
 /// elements of the template are evaluated and combined into a single string to return.
 #[derive(Debug, Clone, Eq, Default)]
 pub struct StringTemplate {
-    template: Template,
+    elements: Vec<Element>,
     decor: Decor,
+    span: Option<Range<usize>>,
 }
 
 impl StringTemplate {
@@ -58,63 +59,120 @@ impl StringTemplate {
     /// Constructs a new, empty `StringTemplate` with at least the specified capacity.
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
-        StringTemplate::from(Template::with_capacity(capacity))
+        StringTemplate {
+            elements: Vec::with_capacity(capacity),
+            ..Default::default()
+        }
     }
 
-    /// Converts the `StringTemplate` into a `Template`, losing the surrounding decor.
-    pub fn into_template(self) -> Template {
-        self.template
+    /// Returns `true` if the template contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Returns the number of elements in the template, also referred to as its 'length'.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Clears the template, removing all elements.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.elements.clear();
+    }
+
+    /// Returns a reference to the element at the given index, or `None` if the index is out of
+    /// bounds.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&Element> {
+        self.elements.get(index)
+    }
+
+    /// Returns a mutable reference to the element at the given index, or `None` if the index is
+    /// out of bounds.
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Element> {
+        self.elements.get_mut(index)
+    }
+
+    /// Inserts an element at position `index` within the template, shifting all elements after it
+    /// to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    #[inline]
+    pub fn insert(&mut self, index: usize, element: impl Into<Element>) {
+        self.elements.insert(index, element.into());
+    }
+
+    /// Appends an element to the back of the template.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    #[inline]
+    pub fn push(&mut self, element: impl Into<Element>) {
+        self.elements.push(element.into());
+    }
+
+    /// Removes the last element from the template and returns it, or [`None`] if it is empty.
+    #[inline]
+    pub fn pop(&mut self) -> Option<Element> {
+        self.elements.pop()
+    }
+
+    /// Removes and returns the element at position `index` within the template, shifting all
+    /// elements after it to the left.
+    ///
+    /// Like `Vec::remove`, the element is removed by shifting all of the elements that follow it,
+    /// preserving their relative order. **This perturbs the index of all of those elements!**
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    #[inline]
+    pub fn remove(&mut self, index: usize) -> Element {
+        self.elements.remove(index)
+    }
+
+    /// An iterator visiting all template elements in insertion order. The iterator element type
+    /// is `&'a Element`.
+    #[inline]
+    pub fn iter(&self) -> Iter<'_> {
+        Box::new(self.elements.iter())
+    }
+
+    /// An iterator visiting all template elements in insertion order, with mutable references to
+    /// the values. The iterator element type is `&'a mut Element`.
+    #[inline]
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        Box::new(self.elements.iter_mut())
     }
 
     pub(crate) fn despan(&mut self, input: &str) {
         self.decor.despan(input);
-        self.template.despan(input);
-    }
-}
-
-impl From<Vec<Element>> for StringTemplate {
-    #[inline]
-    fn from(elements: Vec<Element>) -> Self {
-        StringTemplate::from(Template::from(elements))
-    }
-}
-
-impl From<Template> for StringTemplate {
-    #[inline]
-    fn from(template: Template) -> Self {
-        StringTemplate {
-            template,
-            decor: Decor::default(),
+        for element in &mut self.elements {
+            element.despan(input);
         }
     }
 }
 
-impl From<StringTemplate> for Template {
-    #[inline]
-    fn from(template: StringTemplate) -> Self {
-        template.into_template()
+impl From<Vec<Element>> for StringTemplate {
+    fn from(elements: Vec<Element>) -> Self {
+        StringTemplate {
+            elements,
+            decor: Decor::default(),
+            span: None,
+        }
     }
 }
 
 impl PartialEq for StringTemplate {
     fn eq(&self, other: &Self) -> bool {
-        self.template == other.template
-    }
-}
-
-impl ops::Deref for StringTemplate {
-    type Target = Template;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.template
-    }
-}
-
-impl ops::DerefMut for StringTemplate {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.template
+        self.elements == other.elements
     }
 }
 
@@ -126,7 +184,14 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        self.template.extend(iterable);
+        let iter = iterable.into_iter();
+        let reserve = if self.is_empty() {
+            iter.size_hint().0
+        } else {
+            (iter.size_hint().0 + 1) / 2
+        };
+        self.elements.reserve(reserve);
+        iter.for_each(|v| self.push(v));
     }
 }
 
@@ -138,7 +203,11 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        StringTemplate::from(Template::from_iter(iterable))
+        let iter = iterable.into_iter();
+        let lower = iter.size_hint().0;
+        let mut template = StringTemplate::with_capacity(lower);
+        template.extend(iter);
+        template
     }
 }
 
@@ -147,7 +216,7 @@ impl IntoIterator for StringTemplate {
     type IntoIter = IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.template.into_iter()
+        Box::new(self.elements.into_iter())
     }
 }
 
@@ -156,7 +225,7 @@ impl<'a> IntoIterator for &'a StringTemplate {
     type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.template.iter()
+        self.iter()
     }
 }
 
@@ -165,7 +234,7 @@ impl<'a> IntoIterator for &'a mut StringTemplate {
     type IntoIter = IterMut<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.template.iter_mut()
+        self.iter_mut()
     }
 }
 


### PR DESCRIPTION
This reverts commit 906b3a0ef7ae9299ebda820e0570788688ea9814.