### PR TITLE
refactor(structure)!: remove `BlockBody` and `OnelineBody`

### DIFF
--- a/crates/hcl-edit/src/visit.rs
+++ b/crates/hcl-edit/src/visit.rs
@@ -66,7 +66,7 @@ use crate::expr::{
     TraversalOperator, UnaryOp, UnaryOperator,
 };
 use crate::repr::{Decorated, Formatted, Spanned};
-use crate::structure::{Attribute, Block, BlockBody, BlockLabel, Body, OnelineBody, Structure};
+use crate::structure::{Attribute, Block, BlockLabel, Body, Structure};
 use crate::template::{
     Directive, Element, ElseTemplateExpr, EndforTemplateExpr, EndifTemplateExpr, ForDirective,
     ForTemplateExpr, HeredocTemplate, IfDirective, IfTemplateExpr, Interpolation, StringTemplate,
@@ -119,8 +119,6 @@ pub trait Visit<'ast> {
         visit_attr => Attribute,
         visit_block => Block,
         visit_block_label => BlockLabel,
-        visit_block_body => BlockBody,
-        visit_oneline_body => OnelineBody,
         visit_expr => Expression,
         visit_array => Array,
         visit_object => Object,
@@ -190,7 +188,7 @@ where
     for label in &node.labels {
         v.visit_block_label(label);
     }
-    v.visit_block_body(&node.body);
+    v.visit_body(&node.body);
 }
 
 pub fn visit_block_label<'ast, V>(v: &mut V, node: &'ast BlockLabel)
@@ -200,25 +198,6 @@ where
     match node {
         BlockLabel::String(string) => v.visit_string(string),
         BlockLabel::Ident(ident) => v.visit_ident(ident),
-    }
-}
-
-pub fn visit_block_body<'ast, V>(v: &mut V, node: &'ast BlockBody)
-where
-    V: Visit<'ast> + ?Sized,
-{
-    match node {
-        BlockBody::Oneline(oneline) => v.visit_oneline_body(oneline),
-        BlockBody::Multiline(body) => v.visit_body(body),
-    }
-}
-
-pub fn visit_oneline_body<'ast, V>(v: &mut V, node: &'ast OnelineBody)
-where
-    V: Visit<'ast> + ?Sized,
-{
-    if let Some(attr) = node.as_attribute() {
-        v.visit_attr(attr);
     }
 }
 

--- a/crates/hcl-edit/src/visit_mut.rs
+++ b/crates/hcl-edit/src/visit_mut.rs
@@ -83,7 +83,7 @@ use crate::expr::{
     TraversalOperator, UnaryOp, UnaryOperator,
 };
 use crate::repr::{Decorated, Formatted, Spanned};
-use crate::structure::{Attribute, Block, BlockBody, BlockLabel, Body, OnelineBody, Structure};
+use crate::structure::{Attribute, Block, BlockLabel, Body, Structure};
 use crate::template::{
     Directive, Element, ElseTemplateExpr, EndforTemplateExpr, EndifTemplateExpr, ForDirective,
     ForTemplateExpr, HeredocTemplate, IfDirective, IfTemplateExpr, Interpolation, StringTemplate,
@@ -136,8 +136,6 @@ pub trait VisitMut<'ast> {
         visit_attr_mut => Attribute,
         visit_block_mut => Block,
         visit_block_label_mut => BlockLabel,
-        visit_block_body_mut => BlockBody,
-        visit_oneline_body_mut => OnelineBody,
         visit_expr_mut => Expression,
         visit_array_mut => Array,
         visit_object_mut => Object,
@@ -210,7 +208,7 @@ where
     for label in &mut node.labels {
         v.visit_block_label_mut(label);
     }
-    v.visit_block_body_mut(&mut node.body);
+    v.visit_body_mut(&mut node.body);
 }
 
 pub fn visit_block_label_mut<'ast, V>(v: &mut V, node: &'ast mut BlockLabel)
@@ -220,25 +218,6 @@ where
     match node {
         BlockLabel::String(string) => v.visit_string_mut(string),
         BlockLabel::Ident(ident) => v.visit_ident_mut(ident),
-    }
-}
-
-pub fn visit_block_body_mut<'ast, V>(v: &mut V, node: &'ast mut BlockBody)
-where
-    V: VisitMut<'ast> + ?Sized,
-{
-    match node {
-        BlockBody::Oneline(oneline) => v.visit_oneline_body_mut(oneline),
-        BlockBody::Multiline(body) => v.visit_body_mut(body),
-    }
-}
-
-pub fn visit_oneline_body_mut<'ast, V>(v: &mut V, node: &'ast mut OnelineBody)
-where
-    V: VisitMut<'ast> + ?Sized,
-{
-    if let Some(attr) = node.as_attribute_mut() {
-        v.visit_attr_mut(attr);
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: The `BlockBody` and `OnelineBody` types were removed. `Block` now directly uses `Body`. One-line blocks can still be constructed by calling `body.set_prefer_oneline(true)`.

This removes some unnecessary layer of abstraction which made working with blocks more complicated than it needed to be.