### PR TITLE
refactor!(structure): remove `body` argument from `Block::new`

### DIFF
--- a/crates/hcl-edit/src/parser/structure.rs
+++ b/crates/hcl-edit/src/parser/structure.rs
@@ -67,13 +67,15 @@ fn structure<'i, 's>(
             }
             b'{' => {
                 let (input, body) = block_body(input)?;
-                let block = Block::new(ident, body);
+                let mut block = Block::new(ident);
+                block.body = body;
                 (input, Structure::Block(block))
             }
             ch if ch == b'"' || is_id_start(ch) => {
                 let (input, labels) = block_labels(input)?;
                 let (input, body) = block_body(input)?;
-                let mut block = Block::new(ident, body);
+                let mut block = Block::new(ident);
+                block.body = body;
                 block.labels = labels;
                 (input, Structure::Block(block))
             }

--- a/crates/hcl-edit/src/structure/mod.rs
+++ b/crates/hcl-edit/src/structure/mod.rs
@@ -410,12 +410,12 @@ pub struct Block {
 }
 
 impl Block {
-    /// Creates a new `Block` from an identifier and a block body.
-    pub fn new(ident: impl Into<Decorated<Ident>>, body: impl Into<Body>) -> Block {
+    /// Creates a new `Block` from an identifier.
+    pub fn new(ident: impl Into<Decorated<Ident>>) -> Block {
         Block {
             ident: ident.into(),
             labels: Vec::new(),
-            body: body.into(),
+            body: Body::new(),
             decor: Decor::default(),
             span: None,
         }


### PR DESCRIPTION
BREAKING CHANGE: `Block::new` now only accepts a single `ident` argument. Set the block body, by updating `body` field of `Block`.