### PR TITLE
chore(deps): bump winnow to 0.4.6

### DIFF
--- a/crates/hcl-edit/Cargo.toml
+++ b/crates/hcl-edit/Cargo.toml
@@ -33,7 +33,7 @@ perf = ["hcl-primitives/perf"]
 fnv = "1.0.7"
 hcl-primitives = { version = "0.1.0", path = "../hcl-primitives" }
 vecmap-rs = "0.1.10"
-winnow = "0.4.4"
+winnow = "0.4.6"
 
 [dev-dependencies]
 indoc = "2.0"

--- a/crates/hcl-edit/src/parser/expr.rs
+++ b/crates/hcl-edit/src/parser/expr.rs
@@ -22,12 +22,12 @@ use crate::{
 use std::cell::RefCell;
 use winnow::{
     ascii::{crlf, dec_uint, line_ending, newline, space0},
-    branch::alt,
-    bytes::{any, none_of, one_of, take},
-    combinator::{cut_err, fail, not, opt, peek, repeat1, success},
+    combinator::{
+        alt, cut_err, delimited, fail, not, opt, peek, preceded, repeat, separated0, separated1,
+        separated_pair, success, terminated,
+    },
     dispatch,
-    multi::{separated0, separated1},
-    sequence::{delimited, preceded, separated_pair, terminated},
+    token::{any, none_of, one_of, take},
     Parser,
 };
 
@@ -181,9 +181,12 @@ fn traversal<'i, 's>(
     state: &'s RefCell<ExprParseState>,
 ) -> impl Parser<Input<'i>, (), ParseError<Input<'i>>> + 's {
     move |input: Input<'i>| {
-        repeat1(prefix_decorated(sp, traversal_operator.map(Decorated::new)))
-            .map(|operators| state.borrow_mut().on_traversal(operators))
-            .parse_next(input)
+        repeat(
+            1..,
+            prefix_decorated(sp, traversal_operator.map(Decorated::new)),
+        )
+        .map(|operators| state.borrow_mut().on_traversal(operators))
+        .parse_next(input)
     }
 }
 

--- a/crates/hcl-edit/src/parser/number.rs
+++ b/crates/hcl-edit/src/parser/number.rs
@@ -7,10 +7,8 @@ use crate::Number;
 use std::str::FromStr;
 use winnow::{
     ascii::digit1,
-    branch::alt,
-    bytes::one_of,
-    combinator::{cut_err, opt},
-    sequence::{preceded, terminated},
+    combinator::{alt, cut_err, opt, preceded, terminated},
+    token::one_of,
     Parser,
 };
 

--- a/crates/hcl-edit/src/parser/template.rs
+++ b/crates/hcl-edit/src/parser/template.rs
@@ -17,9 +17,7 @@ use crate::{
 };
 use winnow::{
     ascii::{line_ending, space0},
-    branch::alt,
-    combinator::{opt, repeat0},
-    sequence::{delimited, preceded, separated_pair, terminated},
+    combinator::{alt, delimited, opt, preceded, repeat, separated_pair, terminated},
     Parser,
 };
 
@@ -83,11 +81,14 @@ fn elements<'a, P>(literal: P) -> impl Parser<Input<'a>, Vec<Element>, ParseErro
 where
     P: Parser<Input<'a>, String, ParseError<Input<'a>>>,
 {
-    repeat0(spanned(alt((
-        literal.map(|s| Element::Literal(Spanned::new(s))),
-        interpolation.map(Element::Interpolation),
-        directive.map(Element::Directive),
-    ))))
+    repeat(
+        0..,
+        spanned(alt((
+            literal.map(|s| Element::Literal(Spanned::new(s))),
+            interpolation.map(Element::Interpolation),
+            directive.map(Element::Directive),
+        ))),
+    )
 }
 
 fn interpolation(input: Input) -> IResult<Input, Interpolation> {

--- a/crates/hcl-edit/src/parser/trivia.rs
+++ b/crates/hcl-edit/src/parser/trivia.rs
@@ -1,18 +1,16 @@
 use super::{IResult, Input};
 use winnow::{
     ascii::{multispace0, not_line_ending, space0},
-    branch::alt,
-    bytes::{any, take_until0},
-    combinator::{fail, peek, repeat0},
+    combinator::{alt, delimited, fail, peek, preceded, repeat},
     dispatch,
-    sequence::{delimited, preceded},
+    token::{any, take_until0},
     Parser,
 };
 
 pub(super) fn ws(input: Input) -> IResult<Input, ()> {
     (
         multispace0.void(),
-        void(repeat0((comment, multispace0.void()))),
+        void(repeat(0.., (comment, multispace0.void()))),
     )
         .void()
         .parse_next(input)
@@ -21,7 +19,7 @@ pub(super) fn ws(input: Input) -> IResult<Input, ()> {
 pub(super) fn sp(input: Input) -> IResult<Input, ()> {
     (
         space0.void(),
-        void(repeat0((inline_comment, space0.void()))),
+        void(repeat(0.., (inline_comment, space0.void()))),
     )
         .void()
         .parse_next(input)


### PR DESCRIPTION
This change also migrates a number of deprecated items to their recommended replacements.