### PR TITLE
feat(structure)!: prevent duplicate attribute keys in `Body`

### DIFF
--- a/crates/hcl-edit/src/parser/state.rs
+++ b/crates/hcl-edit/src/parser/state.rs
@@ -52,7 +52,7 @@ impl<'a> BodyParseState<'a> {
     }
 
     pub(super) fn into_body(self) -> Body {
-        Body::from(self.structures)
+        Body::from_vec_unchecked(self.structures)
     }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Various `Body` methods were changed to return `AttributeMut<'a>`/`StructureMut<'a>` instead of `&'a mut Attribute`/`&'a mut Structure` to prevent mutable access to attribute keys. The `VisitMut` trait was updated to reflect these changes as well.

A HCL body must not contain duplicate attribute keys. Multiple instances of the same block identifier are allowed, though. This change updates the `Body` type to make it impossible to insert a given attribute key twice, or to obtain a mutable reference to one.