### PR TITLE
feat(repr): re-export types from crate root

### DIFF
--- a/crates/hcl-edit/src/encode/mod.rs
+++ b/crates/hcl-edit/src/encode/mod.rs
@@ -2,8 +2,7 @@ mod expr;
 mod structure;
 mod template;
 
-use crate::repr::{Decorate, Decorated, Formatted};
-use crate::{Ident, Number};
+use crate::{Decorate, Decorated, Formatted, Ident, Number};
 use std::fmt::{self, Write};
 
 pub(crate) const NO_DECOR: (&str, &str) = ("", "");

--- a/crates/hcl-edit/src/expr/array.rs
+++ b/crates/hcl-edit/src/expr/array.rs
@@ -1,6 +1,5 @@
 use crate::expr::Expression;
-use crate::repr::Decor;
-use crate::RawString;
+use crate::{Decor, RawString};
 use std::ops::Range;
 
 /// An owning iterator over the values of an `Array`.

--- a/crates/hcl-edit/src/expr/conditional.rs
+++ b/crates/hcl-edit/src/expr/conditional.rs
@@ -1,5 +1,5 @@
 use crate::expr::Expression;
-use crate::repr::Decor;
+use crate::Decor;
 use std::ops::Range;
 
 /// The conditional operator allows selecting from one of two expressions based on the outcome of a

--- a/crates/hcl-edit/src/expr/for_expr.rs
+++ b/crates/hcl-edit/src/expr/for_expr.rs
@@ -1,6 +1,5 @@
 use crate::expr::Expression;
-use crate::repr::{Decor, Decorate, Decorated};
-use crate::Ident;
+use crate::{Decor, Decorate, Decorated, Ident};
 use std::ops::Range;
 
 /// A for expression is a construct for constructing a collection by projecting the items from

--- a/crates/hcl-edit/src/expr/func_call.rs
+++ b/crates/hcl-edit/src/expr/func_call.rs
@@ -1,6 +1,5 @@
 use crate::expr::{Expression, IntoIter, Iter, IterMut};
-use crate::repr::{Decor, Decorate, Decorated};
-use crate::{Ident, RawString};
+use crate::{Decor, Decorate, Decorated, Ident, RawString};
 use std::ops::Range;
 
 /// Type representing a function call.

--- a/crates/hcl-edit/src/expr/mod.rs
+++ b/crates/hcl-edit/src/expr/mod.rs
@@ -19,9 +19,8 @@ pub use self::object::{
 pub use self::operation::{BinaryOp, BinaryOperator, UnaryOp, UnaryOperator};
 pub use self::traversal::{Splat, Traversal, TraversalOperator};
 use crate::encode::{EncodeDecorated, EncodeState, NO_DECOR};
-use crate::repr::{Decor, Decorate, Decorated, Formatted};
 use crate::template::{HeredocTemplate, StringTemplate};
-use crate::{parser, Ident, Number};
+use crate::{parser, Decor, Decorate, Decorated, Formatted, Ident, Number};
 use std::fmt;
 use std::ops::Range;
 use std::str::FromStr;

--- a/crates/hcl-edit/src/expr/object.rs
+++ b/crates/hcl-edit/src/expr/object.rs
@@ -1,6 +1,5 @@
 use crate::expr::Expression;
-use crate::repr::{Decor, Decorate, Decorated, Span};
-use crate::{Ident, RawString};
+use crate::{Decor, Decorate, Decorated, Ident, RawString, Span};
 use std::ops::{self, Range};
 use vecmap::map::{MutableKeys, VecMap};
 

--- a/crates/hcl-edit/src/expr/operation.rs
+++ b/crates/hcl-edit/src/expr/operation.rs
@@ -1,5 +1,5 @@
 use crate::expr::Expression;
-use crate::repr::{Decor, Spanned};
+use crate::{Decor, Spanned};
 use std::ops::Range;
 
 // Re-exported for convenience.

--- a/crates/hcl-edit/src/expr/traversal.rs
+++ b/crates/hcl-edit/src/expr/traversal.rs
@@ -1,6 +1,5 @@
 use crate::expr::Expression;
-use crate::repr::{Decor, Decorate, Decorated};
-use crate::Ident;
+use crate::{Decor, Decorate, Decorated, Ident};
 use std::fmt;
 use std::ops::Range;
 

--- a/crates/hcl-edit/src/lib.rs
+++ b/crates/hcl-edit/src/lib.rs
@@ -20,6 +20,7 @@ mod encode;
 pub mod expr;
 pub mod parser;
 mod raw_string;
+#[doc(hidden)]
 pub mod repr;
 pub mod structure;
 pub mod template;
@@ -27,8 +28,9 @@ mod util;
 pub mod visit;
 pub mod visit_mut;
 
-#[doc(inline)]
 pub use self::raw_string::RawString;
+use self::repr::SetSpan;
+pub use self::repr::{Decor, Decorate, Decorated, Formatted, Span, Spanned};
 
 // Re-exported for convenience.
 #[doc(inline)]
@@ -50,5 +52,5 @@ pub use hcl_primitives::{Ident, Number};
 /// assert_eq!(expr.to_string(), r#""A string" // Comment."#);
 /// ```
 pub mod prelude {
-    pub use crate::repr::{Decorate, Span};
+    pub use crate::{Decorate, Span};
 }

--- a/crates/hcl-edit/src/macros.rs
+++ b/crates/hcl-edit/src/macros.rs
@@ -1,19 +1,19 @@
 macro_rules! forward_decorate_impl {
     ($($ty:ident => { $($variant:ident),+ }),+ $(,)?) => {
         $(
-            impl $crate::repr::Decorate for $ty {
-                fn decor(&self) -> &$crate::repr::Decor {
+            impl $crate::Decorate for $ty {
+                fn decor(&self) -> &$crate::Decor {
                     match self {
                         $(
-                            $ty::$variant(v) => $crate::repr::Decorate::decor(v),
+                            $ty::$variant(v) => $crate::Decorate::decor(v),
                         )*
                     }
                 }
 
-                fn decor_mut(&mut self) -> &mut $crate::repr::Decor {
+                fn decor_mut(&mut self) -> &mut $crate::Decor {
                     match self {
                         $(
-                            $ty::$variant(v) => $crate::repr::Decorate::decor_mut(v),
+                            $ty::$variant(v) => $crate::Decorate::decor_mut(v),
                         )*
                     }
                 }
@@ -25,21 +25,21 @@ macro_rules! forward_decorate_impl {
 macro_rules! forward_span_impl {
     ($($ty:ident => { $($variant:ident),+ }),+ $(,)?) => {
         $(
-            impl $crate::repr::Span for $ty {
+            impl $crate::Span for $ty {
                 fn span(&self) -> Option<std::ops::Range<usize>> {
                     match self {
                         $(
-                            $ty::$variant(v) => $crate::repr::Span::span(v),
+                            $ty::$variant(v) => $crate::Span::span(v),
                         )*
                     }
                 }
             }
 
-            impl $crate::repr::SetSpan for $ty {
+            impl $crate::SetSpan for $ty {
                 fn set_span(&mut self, span: std::ops::Range<usize>) {
                     match self {
                         $(
-                            $ty::$variant(v) => $crate::repr::SetSpan::set_span(v, span),
+                            $ty::$variant(v) => $crate::SetSpan::set_span(v, span),
                         )*
                     }
                 }
@@ -51,12 +51,12 @@ macro_rules! forward_span_impl {
 macro_rules! decorate_impl {
     ($($ty:ident),+ $(,)?) => {
         $(
-            impl $crate::repr::Decorate for $ty {
-                fn decor(&self) -> &$crate::repr::Decor {
+            impl $crate::Decorate for $ty {
+                fn decor(&self) -> &$crate::Decor {
                     &self.decor
                 }
 
-                fn decor_mut(&mut self) -> &mut $crate::repr::Decor {
+                fn decor_mut(&mut self) -> &mut $crate::Decor {
                     &mut self.decor
                 }
             }
@@ -67,13 +67,13 @@ macro_rules! decorate_impl {
 macro_rules! span_impl {
     ($($ty:ident),+ $(,)?) => {
         $(
-            impl $crate::repr::Span for $ty {
+            impl $crate::Span for $ty {
                 fn span(&self) -> Option<std::ops::Range<usize>> {
                     self.span.clone()
                 }
             }
 
-            impl $crate::repr::SetSpan for $ty {
+            impl $crate::SetSpan for $ty {
                 fn set_span(&mut self, span: std::ops::Range<usize>) {
                     self.span = Some(span);
                 }

--- a/crates/hcl-edit/src/parser/expr.rs
+++ b/crates/hcl-edit/src/parser/expr.rs
@@ -15,9 +15,8 @@ use crate::{
         Object, ObjectKey, ObjectValue, ObjectValueAssignment, ObjectValueTerminator, Parenthesis,
         Splat, TraversalOperator, UnaryOperator,
     },
-    repr::{Decorate, Decorated, Formatted, SetSpan, Spanned},
     template::HeredocTemplate,
-    Ident, RawString,
+    Decorate, Decorated, Formatted, Ident, RawString, SetSpan, Spanned,
 };
 use std::cell::RefCell;
 use winnow::{

--- a/crates/hcl-edit/src/parser/repr.rs
+++ b/crates/hcl-edit/src/parser/repr.rs
@@ -1,8 +1,5 @@
 use super::{error::ParseError, Input};
-use crate::{
-    repr::{Decorate, SetSpan},
-    RawString,
-};
+use crate::{Decorate, RawString, SetSpan};
 use winnow::Parser;
 
 pub(super) fn spanned<'a, F, O>(inner: F) -> impl Parser<Input<'a>, O, ParseError<Input<'a>>>

--- a/crates/hcl-edit/src/parser/state.rs
+++ b/crates/hcl-edit/src/parser/state.rs
@@ -3,9 +3,8 @@ use crate::{
         BinaryOp, BinaryOperator, Conditional, Expression, Traversal, TraversalOperator, UnaryOp,
         UnaryOperator,
     },
-    repr::{Decorate, Decorated, SetSpan, Spanned},
     structure::{Body, Structure},
-    RawString,
+    Decorate, Decorated, RawString, SetSpan, Spanned,
 };
 use fnv::FnvHashSet;
 use std::ops::Range;

--- a/crates/hcl-edit/src/parser/string.rs
+++ b/crates/hcl-edit/src/parser/string.rs
@@ -4,7 +4,7 @@ use super::{
     trivia::void,
     IResult, Input,
 };
-use crate::{repr::Decorated, Ident, RawString};
+use crate::{Decorated, Ident, RawString};
 use std::borrow::Cow;
 use winnow::{
     combinator::{alt, cut_err, delimited, fail, not, opt, preceded, repeat, success},

--- a/crates/hcl-edit/src/parser/structure.rs
+++ b/crates/hcl-edit/src/parser/structure.rs
@@ -9,8 +9,8 @@ use super::{
 };
 use crate::{
     expr::Expression,
-    repr::{Decorate, Decorated, SetSpan},
     structure::{Attribute, Block, BlockLabel, Body, Structure},
+    Decorate, Decorated, SetSpan,
 };
 use hcl_primitives::Ident;
 use std::cell::RefCell;

--- a/crates/hcl-edit/src/parser/template.rs
+++ b/crates/hcl-edit/src/parser/template.rs
@@ -8,12 +8,12 @@ use super::{
     IResult, Input,
 };
 use crate::{
-    repr::{SetSpan, Span, Spanned},
     template::{
         Directive, Element, ElseTemplateExpr, EndforTemplateExpr, EndifTemplateExpr, ForDirective,
         ForTemplateExpr, IfDirective, IfTemplateExpr, Interpolation, StringTemplate, Strip,
         Template,
     },
+    SetSpan, Span, Spanned,
 };
 use winnow::{
     ascii::{line_ending, space0},

--- a/crates/hcl-edit/src/parser/tests.rs
+++ b/crates/hcl-edit/src/parser/tests.rs
@@ -2,7 +2,7 @@ use super::expr::expr;
 use super::parse_complete;
 use super::structure::body;
 use super::template::template;
-use crate::{expr::Expression, repr::Formatted, Number};
+use crate::{expr::Expression, Formatted, Number};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 

--- a/crates/hcl-edit/src/structure/attribute.rs
+++ b/crates/hcl-edit/src/structure/attribute.rs
@@ -1,6 +1,5 @@
 use crate::expr::Expression;
-use crate::repr::{Decor, Decorate, Decorated, Span};
-use crate::Ident;
+use crate::{Decor, Decorate, Decorated, Ident, Span};
 use std::ops::{self, Range};
 
 /// Represents an HCL attribute which consists of an attribute key and a value expression.

--- a/crates/hcl-edit/src/structure/block.rs
+++ b/crates/hcl-edit/src/structure/block.rs
@@ -1,6 +1,5 @@
-use crate::repr::{Decor, Decorate, Decorated};
 use crate::structure::{Attribute, Body, Structure};
-use crate::Ident;
+use crate::{Decor, Decorate, Decorated, Ident};
 use std::ops::{self, Range};
 
 /// Represents an HCL block which consists of a block identifier, zero or more block labels and a

--- a/crates/hcl-edit/src/structure/body.rs
+++ b/crates/hcl-edit/src/structure/body.rs
@@ -1,7 +1,6 @@
 use crate::encode::{EncodeDecorated, EncodeState, NO_DECOR};
-use crate::parser;
-use crate::repr::Decor;
 use crate::structure::{Attribute, AttributeMut, Block, Structure, StructureMut};
+use crate::{parser, Decor};
 use std::fmt;
 use std::ops::Range;
 use std::str::FromStr;

--- a/crates/hcl-edit/src/structure/mod.rs
+++ b/crates/hcl-edit/src/structure/mod.rs
@@ -10,7 +10,7 @@ pub use self::body::{
     Attributes, AttributesMut, Blocks, BlocksMut, Body, BodyBuilder, IntoAttributes, IntoBlocks,
     IntoIter, Iter, IterMut,
 };
-use crate::repr::{Decor, Decorate, Span};
+use crate::{Decor, Decorate, Span};
 use std::ops::Range;
 
 /// Represents an HCL structure.

--- a/crates/hcl-edit/src/template/mod.rs
+++ b/crates/hcl-edit/src/template/mod.rs
@@ -2,9 +2,8 @@
 
 use crate::encode::{Encode, EncodeState};
 use crate::expr::Expression;
-use crate::repr::{Decor, Decorate, Decorated, Spanned};
 use crate::util::{dedent_by, min_leading_whitespace};
-use crate::{parser, Ident, RawString};
+use crate::{parser, Decor, Decorate, Decorated, Ident, RawString, Spanned};
 use std::fmt;
 use std::ops::Range;
 use std::str::FromStr;

--- a/crates/hcl-edit/src/visit.rs
+++ b/crates/hcl-edit/src/visit.rs
@@ -65,14 +65,13 @@ use crate::expr::{
     FuncCall, Null, Object, ObjectKey, ObjectValue, Parenthesis, Splat, Traversal,
     TraversalOperator, UnaryOp, UnaryOperator,
 };
-use crate::repr::{Decorated, Formatted, Spanned};
 use crate::structure::{Attribute, Block, BlockLabel, Body, Structure};
 use crate::template::{
     Directive, Element, ElseTemplateExpr, EndforTemplateExpr, EndifTemplateExpr, ForDirective,
     ForTemplateExpr, HeredocTemplate, IfDirective, IfTemplateExpr, Interpolation, StringTemplate,
     Template,
 };
-use crate::{Ident, Number};
+use crate::{Decorated, Formatted, Ident, Number, Spanned};
 
 macro_rules! empty_visit_methods {
     ($($name: ident => $t: ty),+ $(,)?) => {

--- a/crates/hcl-edit/src/visit_mut.rs
+++ b/crates/hcl-edit/src/visit_mut.rs
@@ -17,12 +17,11 @@
 //! # use std::error::Error;
 //! #
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! use hcl_edit::Ident;
 //! use hcl_edit::expr::{Expression, Traversal, TraversalOperator};
 //! use hcl_edit::prelude::*;
-//! use hcl_edit::repr::Decorated;
 //! use hcl_edit::structure::Body;
 //! use hcl_edit::visit_mut::{visit_expr_mut, VisitMut};
+//! use hcl_edit::{Decorated, Ident};
 //! use std::str::FromStr;
 //!
 //! struct VariableNamespacer {
@@ -83,14 +82,13 @@ use crate::expr::{
     FuncCall, Null, Object, ObjectKeyMut, ObjectValue, Parenthesis, Splat, Traversal,
     TraversalOperator, UnaryOp, UnaryOperator,
 };
-use crate::repr::{Decorated, Formatted, Spanned};
 use crate::structure::{AttributeMut, Block, BlockLabel, Body, StructureMut};
 use crate::template::{
     Directive, Element, ElseTemplateExpr, EndforTemplateExpr, EndifTemplateExpr, ForDirective,
     ForTemplateExpr, HeredocTemplate, IfDirective, IfTemplateExpr, Interpolation, StringTemplate,
     Template,
 };
-use crate::{Ident, Number};
+use crate::{Decorated, Formatted, Ident, Number, Spanned};
 
 macro_rules! empty_visit_mut_methods {
     ($($name: ident => $t: ty),+ $(,)?) => {


### PR DESCRIPTION
This makes them easier to discover since they are a core feature of `hcl-edit`. At the same time the `repr` module is hidden from the docs and will eventually be made private in a future change.