### PR TITLE
feat(template): add `{escape,unescape}_markers`

### DIFF
--- a/crates/hcl-primitives/src/template.rs
+++ b/crates/hcl-primitives/src/template.rs
@@ -1,5 +1,7 @@
 //! Primitives for the HCL template sub-language.
 
+use alloc::borrow::Cow;
+
 /// Controls the whitespace strip behaviour for template interpolations and directives on adjacent
 /// string literals.
 ///
@@ -76,4 +78,121 @@ impl From<(bool, bool)> for Strip {
             (false, false) => Strip::None,
         }
     }
+}
+
+/// Escapes interpolation sequence (`${`) and directive control flow (`%{`) start markers in a
+/// string literal to `$${` and `%%{` respectively.
+///
+/// ```
+/// use hcl_primitives::template::escape_markers;
+///
+/// assert_eq!(escape_markers("foo"), "foo");
+/// assert_eq!(escape_markers("${interpolation}"), "$${interpolation}");
+/// assert_eq!(escape_markers("$${escaped_interpolation}"), "$$${escaped_interpolation}");
+/// assert_eq!(escape_markers("%{if foo}bar%{else}baz%{endif}"), "%%{if foo}bar%%{else}baz%%{endif}");
+/// ```
+pub fn escape_markers(literal: &str) -> Cow<str> {
+    if literal.len() < 2 {
+        // Fast path: strings shorter than 2 chars cannot contain `${` or `%{`.
+        return Cow::Borrowed(literal);
+    }
+
+    for (idx, window) in literal.as_bytes().windows(2).enumerate() {
+        if let b"${" | b"%{" = window {
+            // Found start marker, enter slow path.
+            return Cow::Owned(escape_markers_owned(literal, idx));
+        }
+    }
+
+    Cow::Borrowed(literal)
+}
+
+fn escape_markers_owned(literal: &str, idx: usize) -> String {
+    let (mut buf, rest) = split_buf(literal, idx);
+    let mut chars = rest.chars();
+
+    while let Some(ch) = chars.next() {
+        buf.push(ch);
+
+        if ch != '$' && ch != '%' {
+            continue;
+        }
+
+        match chars.next() {
+            Some(ch2) => {
+                if ch2 == '{' {
+                    // Escape the start marker by doubling `ch`.
+                    buf.push(ch);
+                }
+
+                buf.push(ch2);
+            }
+            None => break,
+        }
+    }
+
+    buf
+}
+
+/// Unescapes escaped interpolation sequence (`$${`) and directive control flow (`%%{`) start
+/// markers in a string literal to `${` and `%{` respectively.
+///
+/// ```
+/// use hcl_primitives::template::unescape_markers;
+///
+/// assert_eq!(unescape_markers("foo"), "foo");
+/// assert_eq!(unescape_markers("${interpolation}"), "${interpolation}");
+/// assert_eq!(unescape_markers("$${escaped_interpolation}"), "${escaped_interpolation}");
+/// assert_eq!(unescape_markers("$$${escaped_interpolation}"), "$${escaped_interpolation}");
+/// assert_eq!(unescape_markers("%{if foo}bar%{else}baz%{endif}"), "%{if foo}bar%{else}baz%{endif}");
+/// ```
+pub fn unescape_markers(literal: &str) -> Cow<str> {
+    if literal.len() < 3 {
+        // Fast path: strings shorter than 3 chars cannot contain `$${` or `%%{`.
+        return Cow::Borrowed(literal);
+    }
+
+    for (idx, window) in literal.as_bytes().windows(3).enumerate() {
+        if let b"$${" | b"%%{" = window {
+            // Found escaped start marker, enter slow path.
+            return Cow::Owned(unescape_markers_owned(literal, idx));
+        }
+    }
+
+    Cow::Borrowed(literal)
+}
+
+fn unescape_markers_owned(literal: &str, idx: usize) -> String {
+    let (mut buf, rest) = split_buf(literal, idx);
+    let mut chars = rest.chars();
+
+    while let Some(ch) = chars.next() {
+        buf.push(ch);
+
+        if ch != '$' && ch != '%' {
+            continue;
+        }
+
+        match (chars.next(), chars.next()) {
+            (Some(ch2), Some('{')) if ch2 == ch => {
+                // Unescape by not pushing `ch2` to the output buffer.
+                buf.push('{');
+            }
+            (Some(ch2), ch3) => {
+                buf.push(ch2);
+
+                if let Some(ch) = ch3 {
+                    buf.push(ch);
+                }
+            }
+            (_, _) => break,
+        }
+    }
+    buf
+}
+
+fn split_buf(s: &str, idx: usize) -> (String, &str) {
+    let mut buf = String::with_capacity(s.len());
+    buf.push_str(&s[..idx]);
+    (buf, &s[idx..])
 }


### PR DESCRIPTION
This adds functions to escape/unescape interpolation sequence and directive control flow start markers.

These are a prerequisite to properly fix https://github.com/martinohmann/hcl-rs/issues/242.