### PR TITLE
fix(template): properly handle escaping of interpolation/directive markers

### DIFF
--- a/crates/hcl-edit/src/encode/template.rs
+++ b/crates/hcl-edit/src/encode/template.rs
@@ -8,6 +8,7 @@ use crate::template::{
     Strip, Template,
 };
 use crate::util::indent_by;
+use hcl_primitives::template::escape_markers;
 use std::fmt::{self, Write};
 
 const INTERPOLATION_START: &str = "${";
@@ -68,10 +69,11 @@ impl Encode for Element {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
         match self {
             Element::Literal(lit) => {
+                let escaped = escape_markers(lit);
                 if buf.escape() {
-                    encode_escaped(buf, lit)
+                    encode_escaped(buf, &escaped)
                 } else {
-                    buf.write_str(lit)
+                    buf.write_str(&escaped)
                 }
             }
             Element::Interpolation(interp) => interp.encode(buf),

--- a/crates/hcl-edit/src/parser/string.rs
+++ b/crates/hcl-edit/src/parser/string.rs
@@ -17,10 +17,11 @@ use winnow::{
 pub(super) fn string(input: Input) -> IResult<Input, String> {
     delimited(b'"', opt(build_string), b'"')
         .map(Option::unwrap_or_default)
+        .output_into()
         .parse_next(input)
 }
 
-pub(super) fn build_string(input: Input) -> IResult<Input, String> {
+pub(super) fn build_string(input: Input) -> IResult<Input, Cow<str>> {
     let (mut input, mut string) = match string_fragment(input) {
         Ok((input, fragment)) => match fragment {
             StringFragment::Literal(s) => (input, Cow::Borrowed(s)),
@@ -38,7 +39,7 @@ pub(super) fn build_string(input: Input) -> IResult<Input, String> {
                 };
                 input = rest;
             }
-            Err(_) => return Ok((input, string.into())),
+            Err(_) => return Ok((input, string)),
         }
     }
 }

--- a/crates/hcl-rs/src/eval/mod.rs
+++ b/crates/hcl-rs/src/eval/mod.rs
@@ -67,6 +67,25 @@
 //! # }
 //! ```
 //!
+//! If you need to include the literal representation of variable reference, you can escape `${`
+//! with `$${`:
+//!
+//! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use hcl::eval::{Context, Evaluate};
+//! use hcl::Template;
+//! use std::str::FromStr;
+//!
+//! let template = Template::from_str("Value: ${value}, escaped: $${value}")?;
+//! let mut ctx = Context::new();
+//! ctx.declare_var("value", 1);
+//!
+//! let evaluated = "Value: 1, escaped: ${value}";
+//! assert_eq!(template.evaluate(&ctx)?, evaluated);
+//! #   Ok(())
+//! # }
+//! ```
+//!
 //! Here's another example which evaluates some attribute expressions using [`from_str`] as
 //! described in the [deserialization
 //! example][crate::eval#expression-evaluation-during-de-serialization] below:

--- a/crates/hcl-rs/src/format/impls.rs
+++ b/crates/hcl-rs/src/format/impls.rs
@@ -10,6 +10,7 @@ use crate::template::{
 use crate::util::is_templated;
 use crate::{Identifier, Number, Result, Value};
 use hcl_primitives::ident::is_ident;
+use hcl_primitives::template::escape_markers;
 use std::io;
 
 impl<T> private::Sealed for &T where T: Format {}
@@ -466,7 +467,10 @@ impl Format for Element {
         W: io::Write,
     {
         match self {
-            Element::Literal(lit) => fmt.write_string_fragment(lit),
+            Element::Literal(lit) => {
+                let escaped = escape_markers(lit);
+                fmt.write_string_fragment(&escaped)
+            }
             Element::Interpolation(interp) => interp.format(fmt),
             Element::Directive(dir) => dir.format(fmt),
         }

--- a/crates/hcl-rs/src/parser/template.rs
+++ b/crates/hcl-rs/src/parser/template.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::template::{
     Directive, Element, ForDirective, IfDirective, Interpolation, Strip, Template,
 };
+use hcl_primitives::template::unescape_markers;
 
 pub fn template(pair: Pair<Rule>) -> Result<Template> {
     pair.into_inner().map(element).collect()
@@ -9,7 +10,7 @@ pub fn template(pair: Pair<Rule>) -> Result<Template> {
 
 fn element(pair: Pair<Rule>) -> Result<Element> {
     match pair.as_rule() {
-        Rule::TemplateLiteral => Ok(Element::Literal(string(pair))),
+        Rule::TemplateLiteral => Ok(Element::Literal(unescape_markers(pair.as_str()).into())),
         Rule::TemplateInterpolation => interpolation(pair).map(Element::Interpolation),
         Rule::TemplateDirective => directive(inner(pair)).map(Element::Directive),
         rule => unexpected_rule(rule),


### PR DESCRIPTION
Fixes #242
Closes #243

This fixes the handling of `${` and `%{` markers in template literals.

When a HCL template literal contains escaped interpolation sequence or directive control flow start markers (`$${` and `%%{` respectively), they will be automatically unescaped while parsing now.

Additionally, formatting a `Element::Literal` containing `${` or `%{` as HCL will now correctly emit `$${` and `%%{`.