### PR TITLE
fix(parser): correctly handle escaped markers in templates

### DIFF
--- a/crates/hcl-edit/src/parser/string.rs
+++ b/crates/hcl-edit/src/parser/string.rs
@@ -119,9 +119,12 @@ fn any_until<'a, F, T>(literal_end: F) -> impl Parser<Input<'a>, &'a str, ParseE
 where
     F: Parser<Input<'a>, T, ParseError<Input<'a>>>,
 {
-    void(repeat(1.., preceded(not(literal_end), any)))
-        .recognize()
-        .try_map(std::str::from_utf8)
+    void(repeat(
+        1..,
+        preceded(not(alt((escaped_marker.void(), literal_end.void()))), any),
+    ))
+    .recognize()
+    .try_map(std::str::from_utf8)
 }
 
 /// Parse an escaped start marker for a template interpolation or directive.

--- a/crates/hcl-edit/src/parser/tests.rs
+++ b/crates/hcl-edit/src/parser/tests.rs
@@ -2,11 +2,7 @@ use super::expr::expr;
 use super::parse_complete;
 use super::structure::body;
 use super::template::template;
-use crate::{
-    expr::Expression,
-    template::{Element, Interpolation, StringTemplate},
-    Formatted, Ident, Number,
-};
+use crate::{expr::Expression, Formatted, Number};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 
@@ -22,17 +18,6 @@ macro_rules! assert_roundtrip {
 fn number_expr() {
     let parsed = parse_complete("42", expr).unwrap();
     let expected = Expression::Number(Formatted::new(Number::from(42)));
-    assert_eq!(parsed, expected);
-}
-
-#[test]
-fn escaped_string_template() {
-    let parsed = parse_complete(r#""$${escaped} ${unescaped}""#, expr).unwrap();
-    let template = StringTemplate::from_iter([
-        Element::Literal(String::from("${escaped} ").into()),
-        Element::Interpolation(Interpolation::new(Ident::new("unescaped"))),
-    ]);
-    let expected = Expression::Template(template);
     assert_eq!(parsed, expected);
 }
 

--- a/crates/hcl-edit/tests/regressions.rs
+++ b/crates/hcl-edit/tests/regressions.rs
@@ -1,4 +1,7 @@
 use hcl_edit::expr::Expression;
+use hcl_edit::template::{Element, Interpolation, Template};
+use hcl_edit::Ident;
+use pretty_assertions::assert_eq;
 
 // https://github.com/martinohmann/hcl-rs/issues/248
 #[test]
@@ -10,4 +13,18 @@ fn issue_248() {
 
     let parsed: Expression = encoded.parse().unwrap();
     assert_eq!(parsed, expr);
+}
+
+// https://github.com/martinohmann/hcl-rs/issues/256
+#[test]
+fn issue_256() {
+    let input = "$${escaped1} ${unescaped} $${escaped2} $$ESCAPED_SHELL_VAR\n$SHELL_VAR";
+    let parsed: Template = input.parse().unwrap();
+    let expected = Template::from_iter([
+        Element::from("${escaped1} "),
+        Element::from(Interpolation::new(Ident::new("unescaped"))),
+        Element::from(" ${escaped2} $$ESCAPED_SHELL_VAR\n$SHELL_VAR"),
+    ]);
+
+    assert_eq!(parsed, expected);
 }


### PR DESCRIPTION
Fixes #256