### PR TITLE
refactor(template)!: make `StringTemplate` deref to `Template`

### DIFF
--- a/crates/hcl-edit/examples/interpolation-unwrapping.rs
+++ b/crates/hcl-edit/examples/interpolation-unwrapping.rs
@@ -34,8 +34,9 @@
 use hcl_edit::expr::Expression;
 use hcl_edit::prelude::*;
 use hcl_edit::structure::Body;
-use hcl_edit::template::{Element, StringTemplate};
+use hcl_edit::template::{Element, Template};
 use hcl_edit::visit_mut::{visit_expr_mut, VisitMut};
+use std::ops::Deref;
 
 struct InterpolationUnwrapper;
 
@@ -44,7 +45,8 @@ impl VisitMut for InterpolationUnwrapper {
         // Only templates containing a single interpolation can be unwrapped.
         if let Some(interpolation) = expr
             .as_string_template()
-            .and_then(StringTemplate::as_single_element)
+            .map(Deref::deref)
+            .and_then(Template::as_single_element)
             .and_then(Element::as_interpolation)
         {
             let mut unwrapped_expr = interpolation.expr.clone();


### PR DESCRIPTION
This avoids the need to maintain duplicate methods just because of the additional decor that `StringTemplate` has over `Template`. It also enables some other improvements going forward.