### PR TITLE
Remove static newline suffix

### DIFF
--- a/crates/hcl-edit/src/encode/structure.rs
+++ b/crates/hcl-edit/src/encode/structure.rs
@@ -9,7 +9,6 @@ impl Encode for Body {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
         for structure in self.iter() {
             structure.encode_decorated(buf, NO_DECOR)?;
-            buf.write_char('\n')?;
         }
 
         Ok(())

--- a/crates/hcl-edit/src/parser/state.rs
+++ b/crates/hcl-edit/src/parser/state.rs
@@ -40,11 +40,14 @@ impl<'a> BodyParseState<'a> {
         self.current = Some(structure);
     }
 
-    pub(super) fn on_line_ending(&mut self) {
+    pub(super) fn on_line_ending(&mut self, tail: Range<usize>) {
         let mut current = self.current.take().unwrap();
 
-        if let Some(suffix) = self.ws.take() {
+        if let Some(mut suffix) = self.ws.take() {
+            suffix.end = tail.end;
             current.decor_mut().set_suffix(RawString::from_span(suffix));
+        } else {
+            current.decor_mut().set_suffix(RawString::from_span(tail));
         }
 
         self.structures.push(current);

--- a/crates/hcl-edit/src/parser/structure.rs
+++ b/crates/hcl-edit/src/parser/structure.rs
@@ -36,9 +36,12 @@ pub(super) fn body(input: Input) -> IResult<Input, Body> {
                         .span()
                         .map(|span| state.borrow_mut().on_ws(span)),
                 ),
-                cut_err(alt((line_ending, eof)).map(|_| state.borrow_mut().on_line_ending()))
-                    .context(Context::Expected(Expected::Description("newline")))
-                    .context(Context::Expected(Expected::Description("eof"))),
+                cut_err(
+                    (alt((line_ending, eof)).span())
+                        .map(|tail| state.borrow_mut().on_line_ending(tail)),
+                )
+                .context(Context::Expected(Expected::Description("newline")))
+                .context(Context::Expected(Expected::Description("eof"))),
             ),
         ))
         .span(),

--- a/crates/hcl-edit/src/parser/tests.rs
+++ b/crates/hcl-edit/src/parser/tests.rs
@@ -85,6 +85,7 @@ fn roundtrip_body() {
         "#},
         "block { attr = 1 }\n",
         "foo = \"bar\"\nbar = 2\n",
+        "foo = \"bar\"\nbar = 3",
         indoc! {r#"
             indented_heredoc = <<-EOT
                 ${foo}


### PR DESCRIPTION
might fix #270 

I added a test for the body roundtrip that terminates without a newline as a regression test.