### PR TITLE
feat(eval): add `Evaluate::evaluate_in_place`

### DIFF
--- a/crates/hcl-rs/Cargo.toml
+++ b/crates/hcl-rs/Cargo.toml
@@ -45,3 +45,7 @@ vecmap-rs = { version = "0.1.11", features = ["serde"] }
 indoc = "2.0"
 pretty_assertions = "1.4.0"
 serde_json = { version = "1.0.105", features = ["preserve_order"] }
+
+[[example]]
+name = "in-place-expr-evaluation"
+test = true

--- a/crates/hcl-rs/examples/in-place-expr-evaluation.rs
+++ b/crates/hcl-rs/examples/in-place-expr-evaluation.rs
@@ -1,0 +1,134 @@
+use hcl::eval::{Context, Evaluate};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(filename) = std::env::args().into_iter().skip(1).next() else {
+        eprintln!("filename argument required");
+        std::process::exit(1);
+    };
+
+    let input = std::fs::read_to_string(filename)?;
+    let mut body = hcl::parse(&input)?;
+    let ctx = Context::new();
+
+    // This will try to evaluate all expressions in `body` and updates it in-place, returning all
+    // errors that occurred along the way.
+    if let Err(errors) = body.evaluate_in_place(&ctx) {
+        eprintln!("{errors}");
+    }
+
+    hcl::to_writer(std::io::stdout(), &body)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use hcl::eval::{FuncDef, ParamType};
+    use hcl::value::Value;
+    use hcl::Map;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn exprs_are_evaluated_in_place() {
+        let input = indoc::indoc! {r#"
+            resource "aws_eks_cluster" "this" {
+              count = var.create_eks ? 1 : 0
+
+              name     = var.cluster_name
+              role_arn = local.cluster_iam_role_arn
+              version  = var.cluster_version
+
+              vpc_config {
+                security_group_ids = compact([local.cluster_security_group_id])
+                subnet_ids         = var.subnets
+              }
+
+              kubernetes_network_config {
+                service_ipv4_cidr = var.cluster_service_ipv4_cidr
+              }
+
+              tags = merge(
+                var.tags,
+                var.cluster_tags,
+              )
+            }
+        "#};
+
+        let mut body = hcl::parse(&input).unwrap();
+        let mut ctx = Context::new();
+        ctx.declare_var(
+            "var",
+            hcl::value!({
+                "create_eks" = true
+                "cluster_name" = "mycluster"
+                "cluster_tags" = {
+                    "team" = "ops"
+                }
+                "cluster_version" = "1.27.0"
+                "tags" = {
+                    "environment" = "dev"
+                }
+            }),
+        );
+
+        ctx.declare_func(
+            "merge",
+            FuncDef::builder()
+                .variadic_param(ParamType::Any)
+                .build(|args| {
+                    let mut map = Map::<String, Value>::new();
+                    for arg in args.variadic_args() {
+                        if let Some(object) = arg.as_object() {
+                            map.extend(object.clone());
+                        } else {
+                            return Err(format!("Argument {:?} is not an object", arg));
+                        }
+                    }
+
+                    Ok(Value::Object(map))
+                }),
+        );
+
+        let res = body.evaluate_in_place(&ctx);
+        assert!(res.is_err());
+
+        let errors = res.unwrap_err();
+
+        assert_eq!(errors.len(), 4);
+        assert_eq!(
+            errors.to_string(),
+            indoc::indoc! {r#"
+                4 errors occurred:
+                - undefined variable `local` in expression `local.cluster_iam_role_arn`
+                - undefined variable `local` in expression `local.cluster_security_group_id`
+                - no such key: `subnets` in expression `var.subnets`
+                - no such key: `cluster_service_ipv4_cidr` in expression `var.cluster_service_ipv4_cidr`
+            "#}
+        );
+
+        let expected = indoc::indoc! {r#"
+            resource "aws_eks_cluster" "this" {
+              count = 1
+              name = "mycluster"
+              role_arn = local.cluster_iam_role_arn
+              version = "1.27.0"
+
+              vpc_config {
+                security_group_ids = compact([local.cluster_security_group_id])
+                subnet_ids = var.subnets
+              }
+
+              kubernetes_network_config {
+                service_ipv4_cidr = var.cluster_service_ipv4_cidr
+              }
+
+              tags = {
+                "environment" = "dev"
+                "team" = "ops"
+              }
+            }
+        "#};
+
+        assert_eq!(hcl::to_string(&body).unwrap(), expected);
+    }
+}

--- a/crates/hcl-rs/src/eval/error.rs
+++ b/crates/hcl-rs/src/eval/error.rs
@@ -38,6 +38,7 @@ impl Errors {
 
     /// Returns the number of errors.
     #[inline]
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }

--- a/crates/hcl-rs/src/eval/impls.rs
+++ b/crates/hcl-rs/src/eval/impls.rs
@@ -15,6 +15,7 @@ impl Evaluate for Body {
     }
 
     fn evaluate_in_place(&mut self, ctx: &Context) -> EvalResult<(), Errors> {
+        #[allow(clippy::manual_try_fold)]
         self.iter_mut().fold(Ok(()), |res, structure| {
             res.add_errors(structure.evaluate_in_place(ctx))
         })
@@ -146,6 +147,7 @@ where
     }
 
     fn evaluate_in_place(&mut self, ctx: &Context) -> EvalResult<(), Errors> {
+        #[allow(clippy::manual_try_fold)]
         self.iter_mut().fold(Ok(()), |res, element| {
             res.add_errors(element.evaluate_in_place(ctx))
         })
@@ -176,6 +178,7 @@ where
     fn evaluate_in_place(&mut self, ctx: &Context) -> EvalResult<(), Errors> {
         let mut new_object = Object::with_capacity(self.len());
 
+        #[allow(clippy::manual_try_fold)]
         let res = self
             .drain(..)
             .fold(Ok(()), |mut res, (mut key, mut value)| {
@@ -248,6 +251,7 @@ impl Evaluate for Template {
     }
 
     fn evaluate_in_place(&mut self, ctx: &Context) -> EvalResult<(), Errors> {
+        #[allow(clippy::manual_try_fold)]
         self.elements_mut()
             .iter_mut()
             .fold(Ok(()), |mut res, element| match element {
@@ -288,6 +292,7 @@ impl Evaluate for Traversal {
     }
 
     fn evaluate_in_place(&mut self, ctx: &Context) -> EvalResult<(), Errors> {
+        #[allow(clippy::manual_try_fold)]
         self.operators
             .iter_mut()
             .fold(Ok(()), |res, operator| match operator {

--- a/crates/hcl-rs/src/eval/mod.rs
+++ b/crates/hcl-rs/src/eval/mod.rs
@@ -282,7 +282,7 @@ pub trait Evaluate: private::Sealed {
     /// Returns an [`Errors`] value containing one of more [`Error`]s if the evaluation of any
     /// (potentially nested) expression fails.
     ///
-    /// See the errors section of [`Evaluate::evaluate`] for a list of failure modes.
+    /// See the errors section of [`evaluate`][Evaluate::evaluate] for a list of failure modes.
     fn evaluate_in_place(&mut self, ctx: &Context) -> EvalResult<(), Errors> {
         _ = ctx;
         Ok(())

--- a/crates/hcl-rs/src/eval/mod.rs
+++ b/crates/hcl-rs/src/eval/mod.rs
@@ -224,7 +224,7 @@ mod func;
 mod impls;
 mod template;
 
-pub use self::error::{Error, ErrorKind, EvalResult};
+pub use self::error::{Error, ErrorKind, Errors, EvalResult};
 pub use self::func::{
     Func, FuncArgs, FuncDef, FuncDefBuilder, ParamType, PositionalArgs, VariadicArgs,
 };
@@ -275,12 +275,15 @@ pub trait Evaluate: private::Sealed + Sized {
     /// This function does not stop at the first error but continues to evaluate expressions as far
     /// as it can.
     ///
+    /// The default implementation does nothing and always returns `Ok(())`.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the evaluation fails for the same reasons as [`Evaluate::evaluate`].
-    /// The error may return `ErrorKind::Chain(_)` as its [`.kind()`](Error::kind) to denote that
-    /// multiple errors were encountered.
-    fn evaluate_in_place(&mut self, ctx: &Context) -> EvalResult<()> {
+    /// Returns an [`Errors`] value containing one of more [`Error`]s if the evaluation of any
+    /// (potentially nested) expression fails.
+    ///
+    /// See the errors section of [`Evaluate::evaluate`] for a list of failure modes.
+    fn evaluate_in_place(&mut self, ctx: &Context) -> EvalResult<(), Errors> {
         _ = ctx;
         Ok(())
     }

--- a/crates/hcl-rs/src/eval/mod.rs
+++ b/crates/hcl-rs/src/eval/mod.rs
@@ -250,7 +250,7 @@ mod private {
 /// in their fields.
 ///
 /// This trait is sealed to prevent implementation outside of this crate.
-pub trait Evaluate: private::Sealed + Sized {
+pub trait Evaluate: private::Sealed {
     /// The type that is returned by [`evaluate`][Evaluate::evaluate] on success.
     type Output;
 

--- a/crates/hcl-rs/src/eval/mod.rs
+++ b/crates/hcl-rs/src/eval/mod.rs
@@ -250,7 +250,7 @@ mod private {
 /// in their fields.
 ///
 /// This trait is sealed to prevent implementation outside of this crate.
-pub trait Evaluate: private::Sealed {
+pub trait Evaluate: private::Sealed + Sized {
     /// The type that is returned by [`evaluate`][Evaluate::evaluate] on success.
     type Output;
 
@@ -269,6 +269,21 @@ pub trait Evaluate: private::Sealed {
     /// - an undefined variable or function is encountered.
     /// - a defined function is called with unexpected arguments.
     fn evaluate(&self, ctx: &Context) -> EvalResult<Self::Output>;
+
+    /// Recursively tries to evaluate all nested expressions in place.
+    ///
+    /// This function does not stop at the first error but continues to evaluate expressions as far
+    /// as it can.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the evaluation fails for the same reasons as [`Evaluate::evaluate`].
+    /// The error may return `ErrorKind::Chain(_)` as its [`.kind()`](Error::kind) to denote that
+    /// multiple errors were encountered.
+    fn evaluate_in_place(&mut self, ctx: &Context) -> EvalResult<()> {
+        _ = ctx;
+        Ok(())
+    }
 }
 
 /// A type holding the evaluation context.

--- a/crates/hcl-rs/tests/eval.rs
+++ b/crates/hcl-rs/tests/eval.rs
@@ -455,7 +455,7 @@ fn eval_in_place_error() {
         .add_attribute((
             "bar",
             Conditional::new(
-                true,
+                BinaryOp::new(1, BinaryOperator::Less, 2),
                 FuncCall::builder("true_action").arg(1).build(),
                 FuncCall::new("false_action"),
             ),
@@ -470,7 +470,7 @@ fn eval_in_place_error() {
         indoc! {r#"
             2 errors occurred:
             - undefined variable `bar` in expression `1 + bar`
-            - undefined function `true_action` in expression `true ? true_action(1) : false_action()`
+            - undefined function `true_action` in expression `1 < 2 ? true_action(1) : false_action()`
             "#
         }
     )

--- a/crates/hcl-rs/tests/eval.rs
+++ b/crates/hcl-rs/tests/eval.rs
@@ -1,14 +1,14 @@
 mod common;
 
 use common::{assert_eval, assert_eval_ctx, assert_eval_error};
-use hcl::eval::{Context, ErrorKind, EvalResult, FuncArgs, FuncDef, ParamType};
+use hcl::eval::{Context, ErrorKind, EvalResult, Evaluate, FuncArgs, FuncDef, ParamType};
 use hcl::expr::{
     BinaryOp, BinaryOperator, Conditional, Expression, ForExpr, FuncCall, TemplateExpr, Traversal,
     TraversalOperator, Variable,
 };
 use hcl::structure::Body;
 use hcl::template::Template;
-use hcl::{Identifier, Number, Value};
+use hcl::{Attribute, Block, Identifier, Number, Value};
 use indoc::indoc;
 
 #[test]
@@ -381,6 +381,98 @@ fn expr_error_context() {
     assert_eq!(
         err.to_string(),
         r#"eval error: undefined variable `cond` in expression `cond ? "yes" : "no"`"#,
+    )
+}
+
+#[test]
+fn eval_in_place() {
+    let mut ctx = Context::new();
+
+    let mut body = Body::builder()
+        .add_block(
+            Block::builder("foo")
+                .add_attribute(Attribute::new("bar", FuncCall::new("baz")))
+                .add_attribute(Attribute::new(
+                    "qux",
+                    BinaryOp::new(1, BinaryOperator::Plus, 1),
+                ))
+                .build(),
+        )
+        .add_block(
+            Block::builder("bar")
+                .add_attribute(Attribute::new("baz", Variable::unchecked("qux")))
+                .build(),
+        )
+        .build();
+
+    assert_eq!(body.evaluate_in_place(&ctx).unwrap_err().len(), 2);
+
+    let expected = Body::builder()
+        .add_block(
+            Block::builder("foo")
+                .add_attribute(Attribute::new("bar", FuncCall::new("baz")))
+                .add_attribute(Attribute::new("qux", 2))
+                .build(),
+        )
+        .add_block(
+            Block::builder("bar")
+                .add_attribute(Attribute::new("baz", Variable::unchecked("qux")))
+                .build(),
+        )
+        .build();
+
+    assert_eq!(body, expected);
+
+    ctx.declare_var("qux", "quxval");
+    ctx.declare_func("baz", FuncDef::builder().build(|_| Ok(Value::from("baz"))));
+
+    assert!(body.evaluate_in_place(&ctx).is_ok());
+
+    let expected = Body::builder()
+        .add_block(
+            Block::builder("foo")
+                .add_attribute(Attribute::new("bar", "baz"))
+                .add_attribute(Attribute::new("qux", 2))
+                .build(),
+        )
+        .add_block(
+            Block::builder("bar")
+                .add_attribute(Attribute::new("baz", "quxval"))
+                .build(),
+        )
+        .build();
+
+    assert_eq!(body, expected);
+}
+
+#[test]
+fn eval_in_place_error() {
+    let mut body = Body::builder()
+        .add_attribute((
+            "foo",
+            BinaryOp::new(1, BinaryOperator::Plus, Variable::unchecked("bar")),
+        ))
+        .add_attribute((
+            "bar",
+            Conditional::new(
+                true,
+                FuncCall::builder("true_action").arg(1).build(),
+                FuncCall::new("false_action"),
+            ),
+        ))
+        .build();
+
+    let ctx = Context::new();
+    let err = body.evaluate_in_place(&ctx).unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        indoc! {r#"
+            2 errors occurred:
+            - undefined variable `bar` in expression `1 + bar`
+            - undefined function `true_action` in expression `true ? true_action(1) : false_action()`
+            "#
+        }
     )
 }
 


### PR DESCRIPTION
Closes #184.

Key difference to the existing `Evaluate::evaluate` method:

- It mutably borrows the value and tries to evaluate all nested expressions in-place.
- It returns all errors that it encounters, not just the first one.

This allows for partial expression evaluation, e.g. to support use cases where a HCL document contains variable references to other parts within the same document that themselves contain expressions that are not evaluated yet.

In this case one would:

1. Partially evaluate the document via `evaluate_in_place`.
2. Update the `Context` with newly discovered variables.
3. Repeat 1. and 2. until there are no more errors left.