### PR TITLE
expose hcl-edit parser error message

### DIFF
--- a/crates/hcl-edit/src/parser/error.rs
+++ b/crates/hcl-edit/src/parser/error.rs
@@ -21,6 +21,11 @@ impl Error {
         }
     }
 
+    /// Returns the message in the input where the error occurred.
+    pub fn message(&self) -> &str {
+        &self.inner.message
+    }
+
     /// Returns the line from the input where the error occurred.
     ///
     /// Note that this returns the full line containing the invalid input. Use


### PR DESCRIPTION
hcl-edit parser error already returns line and location, but message is also required for the user to be able to pretty print the error themselves