### PR TITLE
feat!: add support for namespaced functions

### DIFF
--- a/crates/hcl-edit/src/encode/expr.rs
+++ b/crates/hcl-edit/src/encode/expr.rs
@@ -191,8 +191,8 @@ impl Encode for FuncCall {
 
 impl Encode for FuncName {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        for ns in &self.namespace {
-            ns.encode_decorated(buf, NO_DECOR)?;
+        for component in &self.namespace {
+            component.encode_decorated(buf, NO_DECOR)?;
             buf.write_str("::")?;
         }
         self.name.encode_decorated(buf, NO_DECOR)

--- a/crates/hcl-edit/src/encode/expr.rs
+++ b/crates/hcl-edit/src/encode/expr.rs
@@ -3,9 +3,9 @@ use super::{
     LEADING_SPACE_DECOR, NO_DECOR, TRAILING_SPACE_DECOR,
 };
 use crate::expr::{
-    Array, BinaryOp, Conditional, Expression, ForCond, ForExpr, ForIntro, FuncArgs, FuncCall, Null,
-    Object, ObjectKey, ObjectValue, ObjectValueAssignment, ObjectValueTerminator, Parenthesis,
-    Splat, Traversal, TraversalOperator, UnaryOp,
+    Array, BinaryOp, Conditional, Expression, ForCond, ForExpr, ForIntro, FuncArgs, FuncCall,
+    FuncName, Null, Object, ObjectKey, ObjectValue, ObjectValueAssignment, ObjectValueTerminator,
+    Parenthesis, Splat, Traversal, TraversalOperator, UnaryOp,
 };
 use std::fmt::{self, Write};
 
@@ -184,8 +184,18 @@ impl Encode for Conditional {
 
 impl Encode for FuncCall {
     fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
-        self.ident.encode_decorated(buf, NO_DECOR)?;
+        self.name.encode(buf)?;
         self.args.encode_decorated(buf, NO_DECOR)
+    }
+}
+
+impl Encode for FuncName {
+    fn encode(&self, buf: &mut EncodeState) -> fmt::Result {
+        for ns in &self.namespace {
+            ns.encode_decorated(buf, NO_DECOR)?;
+            buf.write_str("::")?;
+        }
+        self.name.encode_decorated(buf, NO_DECOR)
     }
 }
 

--- a/crates/hcl-edit/src/expr/func_call.rs
+++ b/crates/hcl-edit/src/expr/func_call.rs
@@ -2,11 +2,116 @@ use crate::expr::{Expression, IntoIter, Iter, IterMut};
 use crate::{Decor, Decorate, Decorated, Ident, RawString};
 use std::ops::Range;
 
+/// Type representing a (potentially namespaced) function name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuncName {
+    /// The function's namespace components, if any.
+    pub namespace: Vec<Decorated<Ident>>,
+    /// The function name.
+    pub name: Decorated<Ident>,
+}
+
+impl FuncName {
+    /// Create a new `FuncName` from a name identifier.
+    pub fn new(name: impl Into<Decorated<Ident>>) -> FuncName {
+        FuncName {
+            namespace: Vec::new(),
+            name: name.into(),
+        }
+    }
+
+    /// Sets the function namespace from an iterator of namespace parts.
+    pub fn set_namespace<I>(&mut self, namespace: I)
+    where
+        I: IntoIterator,
+        I::Item: Into<Decorated<Ident>>,
+    {
+        self.namespace = namespace.into_iter().map(Into::into).collect();
+    }
+
+    /// Returns `true` if the function name is namespaced.
+    ///
+    /// ```
+    /// use hcl_edit::{expr::FuncName, Ident};
+    ///
+    /// let mut func_name = FuncName::new(Ident::new("bar"));
+    ///
+    /// assert!(!func_name.is_namespaced());
+    ///
+    /// func_name.set_namespace([Ident::new("foo")]);
+    ///
+    /// assert!(func_name.is_namespaced());
+    /// ```
+    pub fn is_namespaced(&self) -> bool {
+        !self.namespace.is_empty()
+    }
+
+    /// Returns `true` if the function has the given namespace.
+    ///
+    /// ```
+    /// use hcl_edit::{expr::FuncName, Ident};
+    ///
+    /// let mut func_name = FuncName::new(Ident::new("baz"));
+    ///
+    /// assert!(!func_name.has_namespace(&["foo", "bar"]));
+    ///
+    /// func_name.set_namespace([Ident::new("foo"), Ident::new("bar")]);
+    ///
+    /// assert!(func_name.has_namespace(&["foo", "bar"]));
+    /// assert!(!func_name.has_namespace(&["foo"]));
+    /// assert!(!func_name.has_namespace(&["bar"]));
+    /// ```
+    pub fn has_namespace<T>(&self, namespace: &[T]) -> bool
+    where
+        T: AsRef<str>,
+    {
+        self.namespace.len() == namespace.len()
+            && self
+                .namespace
+                .iter()
+                .zip(namespace.iter())
+                .all(|(a, b)| a.as_str() == b.as_ref())
+    }
+
+    pub(crate) fn despan(&mut self, input: &str) {
+        for scope in &mut self.namespace {
+            scope.decor_mut().despan(input);
+        }
+        self.name.decor_mut().despan(input);
+    }
+}
+
+impl<T> From<T> for FuncName
+where
+    T: Into<Decorated<Ident>>,
+{
+    fn from(name: T) -> Self {
+        FuncName {
+            namespace: Vec::new(),
+            name: name.into(),
+        }
+    }
+}
+
+impl<T, U> From<(T, U)> for FuncName
+where
+    T: IntoIterator,
+    T::Item: Into<Decorated<Ident>>,
+    U: Into<Decorated<Ident>>,
+{
+    fn from((namespace, name): (T, U)) -> Self {
+        FuncName {
+            namespace: namespace.into_iter().map(Into::into).collect(),
+            name: name.into(),
+        }
+    }
+}
+
 /// Type representing a function call.
 #[derive(Debug, Clone, Eq)]
 pub struct FuncCall {
-    /// The function identifier (or name).
-    pub ident: Decorated<Ident>,
+    /// The function name.
+    pub name: FuncName,
     /// The arguments between the function call's `(` and `)` argument delimiters.
     pub args: FuncArgs,
 
@@ -16,9 +121,9 @@ pub struct FuncCall {
 
 impl FuncCall {
     /// Create a new `FuncCall` from an identifier and arguments.
-    pub fn new(ident: impl Into<Decorated<Ident>>, args: FuncArgs) -> FuncCall {
+    pub fn new(name: impl Into<FuncName>, args: FuncArgs) -> FuncCall {
         FuncCall {
-            ident: ident.into(),
+            name: name.into(),
             args,
             decor: Decor::default(),
             span: None,
@@ -27,14 +132,14 @@ impl FuncCall {
 
     pub(crate) fn despan(&mut self, input: &str) {
         self.decor.despan(input);
-        self.ident.decor_mut().despan(input);
+        self.name.despan(input);
         self.args.despan(input);
     }
 }
 
 impl PartialEq for FuncCall {
     fn eq(&self, other: &Self) -> bool {
-        self.ident == other.ident && self.args == other.args
+        self.name == other.name && self.args == other.args
     }
 }
 

--- a/crates/hcl-edit/src/expr/func_call.rs
+++ b/crates/hcl-edit/src/expr/func_call.rs
@@ -30,47 +30,8 @@ impl FuncName {
     }
 
     /// Returns `true` if the function name is namespaced.
-    ///
-    /// ```
-    /// use hcl_edit::{expr::FuncName, Ident};
-    ///
-    /// let mut func_name = FuncName::new(Ident::new("bar"));
-    ///
-    /// assert!(!func_name.is_namespaced());
-    ///
-    /// func_name.set_namespace([Ident::new("foo")]);
-    ///
-    /// assert!(func_name.is_namespaced());
-    /// ```
     pub fn is_namespaced(&self) -> bool {
         !self.namespace.is_empty()
-    }
-
-    /// Returns `true` if the function has the given namespace.
-    ///
-    /// ```
-    /// use hcl_edit::{expr::FuncName, Ident};
-    ///
-    /// let mut func_name = FuncName::new(Ident::new("baz"));
-    ///
-    /// assert!(!func_name.has_namespace(&["foo", "bar"]));
-    ///
-    /// func_name.set_namespace([Ident::new("foo"), Ident::new("bar")]);
-    ///
-    /// assert!(func_name.has_namespace(&["foo", "bar"]));
-    /// assert!(!func_name.has_namespace(&["foo"]));
-    /// assert!(!func_name.has_namespace(&["bar"]));
-    /// ```
-    pub fn has_namespace<T>(&self, namespace: &[T]) -> bool
-    where
-        T: AsRef<str>,
-    {
-        self.namespace.len() == namespace.len()
-            && self
-                .namespace
-                .iter()
-                .zip(namespace.iter())
-                .all(|(a, b)| a.as_str() == b.as_ref())
     }
 
     pub(crate) fn despan(&mut self, input: &str) {

--- a/crates/hcl-edit/src/expr/func_call.rs
+++ b/crates/hcl-edit/src/expr/func_call.rs
@@ -54,20 +54,6 @@ where
     }
 }
 
-impl<T, U> From<(T, U)> for FuncName
-where
-    T: IntoIterator,
-    T::Item: Into<Decorated<Ident>>,
-    U: Into<Decorated<Ident>>,
-{
-    fn from((namespace, name): (T, U)) -> Self {
-        FuncName {
-            namespace: namespace.into_iter().map(Into::into).collect(),
-            name: name.into(),
-        }
-    }
-}
-
 /// Type representing a function call.
 #[derive(Debug, Clone, Eq)]
 pub struct FuncCall {

--- a/crates/hcl-edit/src/expr/mod.rs
+++ b/crates/hcl-edit/src/expr/mod.rs
@@ -11,7 +11,7 @@ mod traversal;
 pub use self::array::{Array, IntoIter, Iter, IterMut};
 pub use self::conditional::Conditional;
 pub use self::for_expr::{ForCond, ForExpr, ForIntro};
-pub use self::func_call::{FuncArgs, FuncCall};
+pub use self::func_call::{FuncArgs, FuncCall, FuncName};
 pub use self::object::{
     Object, ObjectIntoIter, ObjectIter, ObjectIterMut, ObjectKey, ObjectKeyMut, ObjectValue,
     ObjectValueAssignment, ObjectValueTerminator,

--- a/crates/hcl-edit/src/parser/expr.rs
+++ b/crates/hcl-edit/src/parser/expr.rs
@@ -660,11 +660,11 @@ fn identlike<'i, 's>(
             ident.set_span(span);
 
             let func_name = if peeked == b"::" {
-                // Consume the remaining namespace parts and function name.
-                let mut namespace = func_namespace_parts(state).parse_next(input)?;
+                // Consume the remaining namespace components and function name.
+                let mut namespace = func_namespace_components(state).parse_next(input)?;
 
-                // We already parsed the first namespace element before and the function name
-                // is now part of the remaining namspace parts, so we have to correct this.
+                // We already parsed the first namespace element before and the function name is
+                // now part of the remaining namspace components, so we have to correct this.
                 let name = namespace.pop().unwrap();
                 namespace.insert(0, ident);
 
@@ -693,7 +693,7 @@ fn identlike<'i, 's>(
     }
 }
 
-fn func_namespace_parts<'i, 's>(
+fn func_namespace_components<'i, 's>(
     state: &'s RefCell<ExprParseState>,
 ) -> impl Parser<Input<'i>, Vec<Decorated<Ident>>, ContextError> + 's {
     move |input: &mut Input<'i>| {

--- a/crates/hcl-edit/src/parser/expr.rs
+++ b/crates/hcl-edit/src/parser/expr.rs
@@ -656,7 +656,16 @@ fn identlike<'i, 's>(
                 let (mut namespace, func_args): (Vec<Decorated<Ident>>, FuncArgs) = (
                     repeat(
                         1..,
-                        preceded(b"::", decorated(ws_or_sp(state), ident, ws_or_sp(state))),
+                        preceded(
+                            b"::",
+                            decorated(
+                                ws_or_sp(state),
+                                cut_err(ident).context(StrContext::Expected(
+                                    StrContextValue::Description("identifier"),
+                                )),
+                                ws_or_sp(state),
+                            ),
+                        ),
                     ),
                     func_args,
                 )
@@ -725,7 +734,7 @@ fn func_args(input: &mut Input) -> PResult<FuncArgs> {
     };
 
     delimited(
-        b'(',
+        cut_char('('),
         (opt((args, opt(trailer))), raw_string(ws)).map(|(args, trailing)| {
             let mut args = match args {
                 Some((args, Some(trailer))) => {
@@ -745,7 +754,9 @@ fn func_args(input: &mut Input) -> PResult<FuncArgs> {
             args.set_trailing(trailing);
             args
         }),
-        cut_char(')'),
+        cut_char(')').context(StrContext::Expected(StrContextValue::Description(
+            "expression",
+        ))),
     )
     .parse_next(input)
 }

--- a/crates/hcl-edit/src/parser/tests.rs
+++ b/crates/hcl-edit/src/parser/tests.rs
@@ -57,6 +57,8 @@ fn roundtrip_expr() {
         r#""foo ${bar} $${baz}, %{if cond ~} qux %{~ endif}""#,
         r#""${var.l ? "us-east-1." : ""}""#,
         "element(concat(aws_kms_key.key-one.*.arn, aws_kms_key.key-two.*.arn), 0)",
+        "foo::bar(baz...)",
+        "foo :: bar ()",
         "foo(bar...)",
         "foo(bar,)",
         "foo( )",

--- a/crates/hcl-edit/src/visit.rs
+++ b/crates/hcl-edit/src/visit.rs
@@ -62,7 +62,7 @@
 
 use crate::expr::{
     Array, BinaryOp, BinaryOperator, Conditional, Expression, ForCond, ForExpr, ForIntro, FuncArgs,
-    FuncCall, Null, Object, ObjectKey, ObjectValue, Parenthesis, Splat, Traversal,
+    FuncCall, FuncName, Null, Object, ObjectKey, ObjectValue, Parenthesis, Splat, Traversal,
     TraversalOperator, UnaryOp, UnaryOperator,
 };
 use crate::structure::{Attribute, Block, BlockLabel, Body, Structure};
@@ -130,6 +130,7 @@ pub trait Visit {
         visit_traversal => Traversal,
         visit_traversal_operator => TraversalOperator,
         visit_func_call => FuncCall,
+        visit_func_name => FuncName,
         visit_func_args => FuncArgs,
         visit_for_expr => ForExpr,
         visit_for_intro => ForIntro,
@@ -328,8 +329,18 @@ pub fn visit_func_call<V>(v: &mut V, node: &FuncCall)
 where
     V: Visit + ?Sized,
 {
-    v.visit_ident(&node.ident);
+    v.visit_func_name(&node.name);
     v.visit_func_args(&node.args);
+}
+
+pub fn visit_func_name<V>(v: &mut V, node: &FuncName)
+where
+    V: Visit + ?Sized,
+{
+    for ns in &node.namespace {
+        v.visit_ident(ns);
+    }
+    v.visit_ident(&node.name);
 }
 
 pub fn visit_func_args<V>(v: &mut V, node: &FuncArgs)

--- a/crates/hcl-edit/src/visit.rs
+++ b/crates/hcl-edit/src/visit.rs
@@ -337,8 +337,8 @@ pub fn visit_func_name<V>(v: &mut V, node: &FuncName)
 where
     V: Visit + ?Sized,
 {
-    for ns in &node.namespace {
-        v.visit_ident(ns);
+    for component in &node.namespace {
+        v.visit_ident(component);
     }
     v.visit_ident(&node.name);
 }

--- a/crates/hcl-edit/src/visit_mut.rs
+++ b/crates/hcl-edit/src/visit_mut.rs
@@ -353,8 +353,8 @@ pub fn visit_func_name_mut<V>(v: &mut V, node: &mut FuncName)
 where
     V: VisitMut + ?Sized,
 {
-    for ns in &mut node.namespace {
-        v.visit_ident_mut(ns);
+    for component in &mut node.namespace {
+        v.visit_ident_mut(component);
     }
     v.visit_ident_mut(&mut node.name);
 }

--- a/crates/hcl-edit/src/visit_mut.rs
+++ b/crates/hcl-edit/src/visit_mut.rs
@@ -79,7 +79,7 @@
 
 use crate::expr::{
     Array, BinaryOp, BinaryOperator, Conditional, Expression, ForCond, ForExpr, ForIntro, FuncArgs,
-    FuncCall, Null, Object, ObjectKeyMut, ObjectValue, Parenthesis, Splat, Traversal,
+    FuncCall, FuncName, Null, Object, ObjectKeyMut, ObjectValue, Parenthesis, Splat, Traversal,
     TraversalOperator, UnaryOp, UnaryOperator,
 };
 use crate::structure::{AttributeMut, Block, BlockLabel, Body, StructureMut};
@@ -144,6 +144,7 @@ pub trait VisitMut {
         visit_traversal_mut => Traversal,
         visit_traversal_operator_mut => TraversalOperator,
         visit_func_call_mut => FuncCall,
+        visit_func_name_mut => FuncName,
         visit_func_args_mut => FuncArgs,
         visit_for_expr_mut => ForExpr,
         visit_for_intro_mut => ForIntro,
@@ -344,8 +345,18 @@ pub fn visit_func_call_mut<V>(v: &mut V, node: &mut FuncCall)
 where
     V: VisitMut + ?Sized,
 {
-    v.visit_ident_mut(&mut node.ident);
+    v.visit_func_name_mut(&mut node.name);
     v.visit_func_args_mut(&mut node.args);
+}
+
+pub fn visit_func_name_mut<V>(v: &mut V, node: &mut FuncName)
+where
+    V: VisitMut + ?Sized,
+{
+    for ns in &mut node.namespace {
+        v.visit_ident_mut(ns);
+    }
+    v.visit_ident_mut(&mut node.name);
 }
 
 pub fn visit_func_args_mut<V>(v: &mut V, node: &mut FuncArgs)

--- a/crates/hcl-edit/tests/parse.rs
+++ b/crates/hcl-edit/tests/parse.rs
@@ -117,4 +117,37 @@ fn invalid_exprs() {
               |
               = invalid object item; expected `}`, `,` or newline"#}
     );
+
+    assert_error!(
+        "ident = foo::",
+        indoc! {r#"
+             --> HCL parse error in line 1, column 14
+              |
+            1 | ident = foo::
+              |              ^---
+              |
+              = expected identifier"#}
+    );
+
+    assert_error!(
+        "ident = foo::bar",
+        indoc! {r#"
+             --> HCL parse error in line 1, column 17
+              |
+            1 | ident = foo::bar
+              |                 ^---
+              |
+              = expected `(`"#}
+    );
+
+    assert_error!(
+        "ident = foo( ",
+        indoc! {r#"
+             --> HCL parse error in line 1, column 14
+              |
+            1 | ident = foo( 
+              |              ^---
+              |
+              = expected `)` or expression"#}
+    );
 }

--- a/crates/hcl-rs/src/eval/error.rs
+++ b/crates/hcl-rs/src/eval/error.rs
@@ -196,7 +196,7 @@ pub enum ErrorKind {
     /// An expression contained an undefined variable.
     UndefinedVar(Identifier),
     /// An expression contained a call to an undefined function.
-    UndefinedFunc(Identifier),
+    UndefinedFunc(FuncName),
     /// A different type of value was expected.
     Unexpected(Value, &'static str),
     /// An expression tried to access a non-existing array index.
@@ -210,7 +210,7 @@ pub enum ErrorKind {
     /// A `for` expression attempted to set the same object key twice.
     KeyExists(String),
     /// A function call in an expression returned an error.
-    FuncCall(Identifier, String),
+    FuncCall(FuncName, String),
     /// It was attempted to evaluate a raw expression.
     #[deprecated(
         since = "0.16.3",
@@ -244,8 +244,8 @@ impl fmt::Display for ErrorKind {
             ErrorKind::UndefinedVar(ident) => {
                 write!(f, "undefined variable `{ident}`")
             }
-            ErrorKind::UndefinedFunc(ident) => {
-                write!(f, "undefined function `{ident}`")
+            ErrorKind::UndefinedFunc(func_name) => {
+                write!(f, "undefined function `{func_name}`")
             }
             ErrorKind::Unexpected(value, expected) => {
                 write!(f, "unexpected value `{value}`, expected {expected}")

--- a/crates/hcl-rs/src/expr/edit.rs
+++ b/crates/hcl-rs/src/expr/edit.rs
@@ -130,11 +130,29 @@ impl From<ForExpr> for expr::ForExpr {
     }
 }
 
+impl From<expr::FuncName> for FuncName {
+    fn from(value: expr::FuncName) -> Self {
+        FuncName {
+            namespace: value.namespace.into_iter().map(Into::into).collect(),
+            name: value.name.into(),
+        }
+    }
+}
+
+impl From<FuncName> for expr::FuncName {
+    fn from(value: FuncName) -> Self {
+        expr::FuncName {
+            namespace: value.namespace.into_iter().map(Into::into).collect(),
+            name: value.name.into(),
+        }
+    }
+}
+
 impl From<expr::FuncCall> for FuncCall {
     fn from(value: expr::FuncCall) -> Self {
         let expand_final = value.args.expand_final();
         FuncCall {
-            name: value.ident.into(),
+            name: value.name.into(),
             args: value.args.into_iter().map(Into::into).collect(),
             expand_final,
         }

--- a/crates/hcl-rs/src/expr/func_call.rs
+++ b/crates/hcl-rs/src/expr/func_call.rs
@@ -33,53 +33,8 @@ impl FuncName {
     }
 
     /// Returns `true` if the function name is namespaced.
-    ///
-    /// ```
-    /// use hcl::{expr::FuncName, Identifier};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut func_name = FuncName::new(Identifier::new("bar")?);
-    ///
-    /// assert!(!func_name.is_namespaced());
-    ///
-    /// func_name = func_name.with_namespace([Identifier::new("foo")?]);
-    ///
-    /// assert!(func_name.is_namespaced());
-    /// #   Ok(())
-    /// # }
-    /// ```
     pub fn is_namespaced(&self) -> bool {
         !self.namespace.is_empty()
-    }
-
-    /// Returns `true` if the function has the given namespace.
-    ///
-    /// ```
-    /// use hcl::{expr::FuncName, Identifier};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut func_name = FuncName::new(Identifier::new("baz")?);
-    ///
-    /// assert!(!func_name.has_namespace(&["foo", "bar"]));
-    ///
-    /// func_name = func_name.with_namespace([Identifier::new("foo")?, Identifier::new("bar")?]);
-    ///
-    /// assert!(func_name.has_namespace(&["foo", "bar"]));
-    /// assert!(!func_name.has_namespace(&["foo"]));
-    /// assert!(!func_name.has_namespace(&["bar"]));
-    /// #   Ok(())
-    /// # }
-    /// ```
-    pub fn has_namespace<T>(&self, namespace: &[T]) -> bool
-    where
-        T: AsRef<str>,
-    {
-        self.namespace.len() == namespace.len()
-            && self
-                .namespace
-                .iter()
-                .zip(namespace.iter())
-                .all(|(a, b)| a.as_str() == b.as_ref())
     }
 }
 
@@ -120,7 +75,7 @@ impl fmt::Display for FuncName {
 /// Represents a function call expression with zero or more arguments.
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct FuncCall {
-    /// The name of the function.
+    /// The function name.
     pub name: FuncName,
     /// The function arguments.
     pub args: Vec<Expression>,

--- a/crates/hcl-rs/src/expr/func_call.rs
+++ b/crates/hcl-rs/src/expr/func_call.rs
@@ -50,20 +50,6 @@ where
     }
 }
 
-impl<T, U> From<(T, U)> for FuncName
-where
-    T: IntoIterator,
-    T::Item: Into<Identifier>,
-    U: Into<Identifier>,
-{
-    fn from((namespace, name): (T, U)) -> Self {
-        FuncName {
-            namespace: namespace.into_iter().map(Into::into).collect(),
-            name: name.into(),
-        }
-    }
-}
-
 impl fmt::Display for FuncName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Formatting a `FuncName` as string cannot fail.

--- a/crates/hcl-rs/src/expr/mod.rs
+++ b/crates/hcl-rs/src/expr/mod.rs
@@ -20,7 +20,7 @@ use self::ser::ExpressionSerializer;
 pub use self::{
     conditional::Conditional,
     for_expr::ForExpr,
-    func_call::{FuncCall, FuncCallBuilder},
+    func_call::{FuncCall, FuncCallBuilder, FuncName},
     operation::{BinaryOp, BinaryOperator, Operation, UnaryOp, UnaryOperator},
     template_expr::{Heredoc, HeredocStripMode, TemplateExpr},
     traversal::{Traversal, TraversalBuilder, TraversalOperator},

--- a/crates/hcl-rs/src/format/impls.rs
+++ b/crates/hcl-rs/src/format/impls.rs
@@ -2,8 +2,8 @@ use super::{private, Format, Formatter};
 #[allow(deprecated)]
 use crate::expr::RawExpression;
 use crate::expr::{
-    BinaryOp, Conditional, Expression, ForExpr, FuncCall, Heredoc, HeredocStripMode, ObjectKey,
-    Operation, TemplateExpr, Traversal, TraversalOperator, UnaryOp, Variable,
+    BinaryOp, Conditional, Expression, ForExpr, FuncCall, FuncName, Heredoc, HeredocStripMode,
+    ObjectKey, Operation, TemplateExpr, Traversal, TraversalOperator, UnaryOp, Variable,
 };
 use crate::structure::{Attribute, Block, BlockLabel, Body, Structure};
 use crate::template::{
@@ -348,6 +348,22 @@ impl Format for FuncCall {
         } else {
             fmt.write_bytes(b")")
         }
+    }
+}
+
+impl private::Sealed for FuncName {}
+
+impl Format for FuncName {
+    fn format<W>(&self, fmt: &mut Formatter<W>) -> Result<()>
+    where
+        W: io::Write,
+    {
+        for ns in &self.namespace {
+            ns.format(fmt)?;
+            fmt.write_bytes(b"::")?;
+        }
+
+        self.name.format(fmt)
     }
 }
 

--- a/crates/hcl-rs/src/format/impls.rs
+++ b/crates/hcl-rs/src/format/impls.rs
@@ -358,8 +358,8 @@ impl Format for FuncName {
     where
         W: io::Write,
     {
-        for ns in &self.namespace {
-            ns.format(fmt)?;
+        for component in &self.namespace {
+            component.format(fmt)?;
             fmt.write_bytes(b"::")?;
         }
 

--- a/crates/hcl-rs/tests/format.rs
+++ b/crates/hcl-rs/tests/format.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::{assert_format, assert_format_builder};
 use hcl::expr::{
-    BinaryOp, BinaryOperator, Conditional, Expression, ForExpr, FuncCall, Heredoc,
+    BinaryOp, BinaryOperator, Conditional, Expression, ForExpr, FuncCall, FuncName, Heredoc,
     HeredocStripMode, Traversal, TraversalOperator, Variable,
 };
 use hcl::format::Formatter;
@@ -101,6 +101,20 @@ fn func_call_expand_final() {
             .build(),
         indoc! {r#"
             func(1, ["two", "three"]...)
+        "#}
+        .trim_end(),
+    );
+}
+
+#[test]
+fn namespaced_func_call() {
+    assert_format(
+        FuncCall::builder(FuncName::new("func").with_namespace(["some", "namespaced"]))
+            .arg(1)
+            .arg(2)
+            .build(),
+        indoc! {r#"
+            some::namespaced::func(1, 2)
         "#}
         .trim_end(),
     );


### PR DESCRIPTION
Closes https://github.com/martinohmann/hcl-rs/issues/335

This adds support for namespaced HCL function calls. The PR includes updates to the HCL parser (`hcl-edit`), formatter (`hcl-rs`), evaluation context (`hcl-rs`), encoder (`hcl-edit`) and visitors (`hcl-edit`).

BREAKING CHANGE: The `ident` field of `hcl_edit::expr::FuncCall` was renamed to `name`. Its type changed from `Decorated<Ident>` to `FuncName`. The type of `hcl::expr::FuncCall`'s `name` field changed from `Identifier` to `FuncName`. Various other places in the codebase that previously used bare identifiers as type now use `FuncName` to accommodate the change.