### PR TITLE
feat: add `from_value` function for deserializing HCL `Value`.

### DIFF
--- a/crates/hcl-rs/src/lib.rs
+++ b/crates/hcl-rs/src/lib.rs
@@ -85,4 +85,4 @@ pub use structure::{BlockBuilder, BodyBuilder};
 pub use template::Template;
 
 #[doc(inline)]
-pub use value::{to_value, Map, Value};
+pub use value::{from_value, to_value, Map, Value};

--- a/crates/hcl-rs/src/value/mod.rs
+++ b/crates/hcl-rs/src/value/mod.rs
@@ -208,7 +208,7 @@ impl fmt::Display for Value {
     }
 }
 
-/// Convert a `T` into [`Value`] which is an enum that can represent any valid HCL value.
+/// Convert a `T` into `hcl::Value` which is an enum that can represent any valid HCL value.
 ///
 /// # Example
 ///
@@ -253,7 +253,7 @@ where
     value.serialize(ValueSerializer)
 }
 
-/// Convert a [`Value`] into a type `T` that implements [`serde::de::Deserialize`].
+/// Convert a `hcl::Value` into a type `T` that implements `serde::Deserialize`.
 ///
 /// # Example
 ///
@@ -290,7 +290,7 @@ where
 ///
 /// # Errors
 ///
-/// This conversion can fail if `T`'s implementation of [`serde::de::Deserialize`] decides to fail.
+/// This conversion can fail if `T`'s implementation of [`serde::Deserialize`] decides to fail.
 pub fn from_value<T>(value: Value) -> Result<T>
 where
     T: DeserializeOwned,

--- a/crates/hcl-rs/src/value/mod.rs
+++ b/crates/hcl-rs/src/value/mod.rs
@@ -262,7 +262,7 @@ where
 /// use hcl::{Map, Value};
 /// use serde::Deserialize;
 ///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, Deserialize, PartialEq)]
 /// struct Custom {
 ///     foo: String,
 ///     bar: u64,


### PR DESCRIPTION
Add the `from_value` function to the `value` module, allowing users to convert a `Value` into a type `T` that implements `serde::de::Deserialize`.

Providing a convenient way to deserialize HCL `Value` into Rust types.

close #345