### PR TITLE
fix(parser): switch from `&[u8]` to `&str` based stream

### DIFF
--- a/crates/hcl-edit/src/parser/error.rs
+++ b/crates/hcl-edit/src/parser/error.rs
@@ -115,10 +115,9 @@ impl Location {
         self.offset
     }
 }
-
-fn locate_error<'a>(err: &ParseError<Input<'a>, ContextError>) -> (&'a [u8], Location) {
+fn locate_error<'a>(err: &'a ParseError<Input<'a>, ContextError>) -> (&'a [u8], Location) {
     let offset = err.offset();
-    let input = err.input();
+    let input = err.input().as_bytes();
     let remaining_input = &input[offset..];
     let consumed_input = &input[..offset];
 

--- a/crates/hcl-edit/src/parser/mod.rs
+++ b/crates/hcl-edit/src/parser/mod.rs
@@ -25,7 +25,7 @@ mod prelude {
     pub(super) use winnow::stream::Stream;
     pub(super) use winnow::{dispatch, PResult, Parser};
 
-    pub(super) type Input<'a> = winnow::stream::Located<&'a [u8]>;
+    pub(super) type Input<'a> = winnow::stream::Located<&'a str>;
 }
 
 use self::prelude::*;
@@ -67,7 +67,7 @@ fn parse_complete<'a, P, O>(input: &'a str, mut parser: P) -> Result<O, Error>
 where
     P: Parser<Input<'a>, O, ContextError>,
 {
-    let input = Input::new(input.as_bytes());
+    let input = Input::new(input);
 
     parser
         .parse(input)

--- a/crates/hcl-edit/src/parser/number.rs
+++ b/crates/hcl-edit/src/parser/number.rs
@@ -1,7 +1,5 @@
 use super::prelude::*;
 
-use super::string::from_utf8_unchecked;
-
 use crate::Number;
 
 use std::str::FromStr;
@@ -18,27 +16,19 @@ pub(super) fn number(input: &mut Input) -> PResult<Number> {
 }
 
 fn integer(input: &mut Input) -> PResult<u64> {
-    digit1
-        .try_map(|s: &[u8]| {
-            u64::from_str(unsafe { from_utf8_unchecked(s, "`digit1` filters out non-ascii") })
-        })
-        .parse_next(input)
+    digit1.try_map(|s: &str| u64::from_str(s)).parse_next(input)
 }
 
 fn float(input: &mut Input) -> PResult<f64> {
-    let fraction = preceded(b'.', digit1);
+    let fraction = preceded('.', digit1);
 
     terminated(digit1, alt((terminated(fraction, opt(exponent)), exponent)))
         .recognize()
-        .try_map(|s: &[u8]| {
-            f64::from_str(unsafe {
-                from_utf8_unchecked(s, "`digit1` and `exponent` filter out non-ascii")
-            })
-        })
+        .try_map(|s: &str| f64::from_str(s))
         .parse_next(input)
 }
 
-fn exponent<'a>(input: &mut Input<'a>) -> PResult<&'a [u8]> {
+fn exponent<'a>(input: &mut Input<'a>) -> PResult<&'a str> {
     (
         one_of(b"eE"),
         opt(one_of(b"+-")),
@@ -63,7 +53,7 @@ mod tests {
         ];
 
         for (input, expected) in tests {
-            let parsed = integer.parse(Input::new(input.as_bytes()));
+            let parsed = integer.parse(Input::new(input));
             assert!(parsed.is_ok(), "expected `{input}` to parse correctly");
             assert_eq!(parsed.unwrap(), *expected);
         }
@@ -81,7 +71,7 @@ mod tests {
         ];
 
         for (input, expected) in tests {
-            let parsed = float.parse(Input::new(input.as_bytes()));
+            let parsed = float.parse(Input::new(input));
             assert!(parsed.is_ok(), "expected `{input}` to parse correctly");
             assert_eq!(parsed.unwrap(), *expected);
         }

--- a/crates/hcl-edit/src/parser/structure.rs
+++ b/crates/hcl-edit/src/parser/structure.rs
@@ -3,13 +3,14 @@ use super::prelude::*;
 use super::expr::expr;
 use super::repr::{decorated, prefix_decorated, suffix_decorated};
 use super::state::BodyParseState;
-use super::string::{cut_char, cut_str_ident, ident, is_id_start, raw_string, string};
+use super::string::{cut_char, cut_str_ident, ident, raw_string, string};
 use super::trivia::{line_comment, sp, void, ws};
 
 use crate::expr::Expression;
 use crate::structure::{Attribute, Block, BlockLabel, Body, Structure};
 use crate::{Decorate, Decorated, Ident, SetSpan};
 
+use hcl_primitives::ident::is_id_start;
 use std::cell::RefCell;
 use winnow::ascii::line_ending;
 use winnow::combinator::{
@@ -64,7 +65,7 @@ fn structure<'i, 's>(
         let suffix = raw_string(sp).parse_next(input)?;
 
         let mut structure = match peek(any).parse_next(input)? {
-            b'=' => {
+            '=' => {
                 if state.borrow_mut().is_redefined(ident) {
                     input.reset(&checkpoint);
                     return cut_err(fail)
@@ -82,7 +83,7 @@ fn structure<'i, 's>(
                 let attr = Attribute::new(ident, expr);
                 Structure::Attribute(attr)
             }
-            b'{' => {
+            '{' => {
                 let body = block_body(input)?;
                 let mut ident = Decorated::new(Ident::new_unchecked(ident));
                 ident.decor_mut().set_suffix(suffix);
@@ -91,7 +92,7 @@ fn structure<'i, 's>(
                 block.body = body;
                 Structure::Block(block)
             }
-            ch if ch == b'"' || is_id_start(ch) => {
+            ch if ch == '"' || is_id_start(ch) => {
                 let labels = block_labels(input)?;
                 let body = block_body(input)?;
                 let mut ident = Decorated::new(Ident::new_unchecked(ident));

--- a/crates/hcl-edit/src/parser/trivia.rs
+++ b/crates/hcl-edit/src/parser/trivia.rs
@@ -24,8 +24,8 @@ pub(super) fn sp(input: &mut Input) -> PResult<()> {
 
 fn comment(input: &mut Input) -> PResult<()> {
     dispatch! {peek(any);
-        b'#' => hash_line_comment,
-        b'/' => alt((double_slash_line_comment, inline_comment)),
+        '#' => hash_line_comment,
+        '/' => alt((double_slash_line_comment, inline_comment)),
         _ => fail,
     }
     .parse_next(input)
@@ -33,23 +33,23 @@ fn comment(input: &mut Input) -> PResult<()> {
 
 pub(super) fn line_comment(input: &mut Input) -> PResult<()> {
     dispatch! {peek(any);
-        b'#' => hash_line_comment,
-        b'/' => double_slash_line_comment,
+        '#' => hash_line_comment,
+        '/' => double_slash_line_comment,
         _ => fail,
     }
     .parse_next(input)
 }
 
 fn hash_line_comment(input: &mut Input) -> PResult<()> {
-    preceded(b'#', till_line_ending).void().parse_next(input)
+    preceded('#', till_line_ending).void().parse_next(input)
 }
 
 fn double_slash_line_comment(input: &mut Input) -> PResult<()> {
-    preceded(b"//", till_line_ending).void().parse_next(input)
+    preceded("//", till_line_ending).void().parse_next(input)
 }
 
 fn inline_comment(input: &mut Input) -> PResult<()> {
-    delimited(b"/*", take_until(0.., "*/"), b"*/")
+    delimited("/*", take_until(0.., "*/"), "*/")
         .void()
         .parse_next(input)
 }
@@ -92,17 +92,17 @@ mod tests {
         ];
 
         for input in inline_comments {
-            let parsed = sp.parse(Input::new(input.as_bytes()));
+            let parsed = sp.parse(Input::new(input));
             assert!(parsed.is_ok(), "expected `{input}` to parse correctly");
         }
 
         for input in multiline_comments {
-            let parsed = sp.parse(Input::new(input.as_bytes()));
+            let parsed = sp.parse(Input::new(input));
             assert!(parsed.is_err(), "expected parse error for `{input}`");
         }
 
         for input in inline_comments.iter().chain(multiline_comments.iter()) {
-            let parsed = ws.parse(Input::new(input.as_bytes()));
+            let parsed = ws.parse(Input::new(input));
             assert!(parsed.is_ok(), "expected `{input}` to parse correctly");
         }
     }

--- a/crates/hcl-edit/tests/regressions.rs
+++ b/crates/hcl-edit/tests/regressions.rs
@@ -165,3 +165,17 @@ fn issue_319() {
             [2]
     "#};
 }
+
+// https://github.com/martinohmann/hcl-rs/issues/350
+#[test]
+fn issue_350() {
+    let unicode_input = r#"
+        locals {
+            é = 4
+        }
+        output "ééé" {
+            value = local.é
+        }
+    "#;
+    assert!(unicode_input.parse::<Body>().is_ok());
+}


### PR DESCRIPTION
Fixes https://github.com/martinohmann/hcl-rs/issues/350

This fixes an unsoundness around handling of UTF-8 identifiers in the parser at the expense of decreasing the performance by around 20-30%.

I may switch back to a `&[u8]` based stream once I figured out how to handle UTF-8 identifiers with it safely without adding a truck load of complexity, but for now correctness is more important than performance.