### PR TITLE
fix!: remove deprecated items

### DIFF
--- a/crates/hcl-rs/src/eval/error.rs
+++ b/crates/hcl-rs/src/eval/error.rs
@@ -211,12 +211,6 @@ pub enum ErrorKind {
     KeyExists(String),
     /// A function call in an expression returned an error.
     FuncCall(FuncName, String),
-    /// It was attempted to evaluate a raw expression.
-    #[deprecated(
-        since = "0.16.3",
-        note = "Support for raw expressions will be removed in an upcoming release"
-    )]
-    RawExpression,
 }
 
 impl From<Error> for ErrorKind {
@@ -264,8 +258,6 @@ impl fmt::Display for ErrorKind {
             ErrorKind::FuncCall(name, msg) => {
                 write!(f, "error calling function `{name}`: {msg}")
             }
-            #[allow(deprecated)]
-            ErrorKind::RawExpression => f.write_str("raw expressions cannot be evaluated"),
         }
     }
 }

--- a/crates/hcl-rs/src/eval/impls.rs
+++ b/crates/hcl-rs/src/eval/impls.rs
@@ -95,8 +95,6 @@ impl Evaluate for Expression {
             Expression::Conditional(cond) => cond.evaluate(ctx),
             Expression::Operation(op) => op.evaluate(ctx),
             Expression::ForExpr(expr) => expr.evaluate(ctx),
-            #[allow(deprecated)]
-            Expression::Raw(_) => Err(ctx.error(ErrorKind::RawExpression)),
             other => Ok(Value::from(other.clone())),
         }
     }

--- a/crates/hcl-rs/src/expr/de.rs
+++ b/crates/hcl-rs/src/expr/de.rs
@@ -51,7 +51,6 @@ impl<'de> de::Deserialize<'de> for Expression {
             Conditional,
             Operation,
             ForExpr,
-            Raw,
         }
 
         struct FieldVisitor;
@@ -82,10 +81,9 @@ impl<'de> de::Deserialize<'de> for Expression {
                     11u64 => Ok(Field::Conditional),
                     12u64 => Ok(Field::Operation),
                     13u64 => Ok(Field::ForExpr),
-                    14u64 => Ok(Field::Raw),
                     _ => Err(de::Error::invalid_value(
                         Unexpected::Unsigned(value),
-                        &"variant index 0 <= i < 15",
+                        &"variant index 0 <= i < 14",
                     )),
                 }
             }
@@ -109,7 +107,6 @@ impl<'de> de::Deserialize<'de> for Expression {
                     "Conditional" => Ok(Field::Conditional),
                     "Operation" => Ok(Field::Operation),
                     "ForExpr" => Ok(Field::ForExpr),
-                    "Raw" => Ok(Field::Raw),
                     _ => Err(de::Error::unknown_variant(value, VARIANTS)),
                 }
             }
@@ -133,7 +130,6 @@ impl<'de> de::Deserialize<'de> for Expression {
                     b"Conditional" => Ok(Field::Conditional),
                     b"Operation" => Ok(Field::Operation),
                     b"ForExpr" => Ok(Field::ForExpr),
-                    b"Raw" => Ok(Field::Raw),
                     _ => {
                         let value = &String::from_utf8_lossy(value);
                         Err(de::Error::unknown_variant(value, VARIANTS))
@@ -248,7 +244,6 @@ impl<'de> de::Deserialize<'de> for Expression {
                     (Field::Conditional, v) => v.newtype_variant().map(Expression::Conditional),
                     (Field::Operation, v) => v.newtype_variant().map(Expression::Operation),
                     (Field::ForExpr, v) => v.newtype_variant().map(Expression::ForExpr),
-                    (Field::Raw, v) => v.newtype_variant().map(Expression::Raw),
                 }
             }
         }
@@ -268,7 +263,6 @@ impl<'de> de::Deserialize<'de> for Expression {
             "Conditional",
             "Operation",
             "ForExpr",
-            "Raw",
         ];
 
         deserializer.deserialize_enum("$hcl::Expression", VARIANTS, ExpressionVisitor)
@@ -558,7 +552,6 @@ impl<'de> de::VariantAccess<'de> for Expression {
             Expression::String(v) => seed.deserialize(v.into_deserializer()),
             Expression::Array(v) => seed.deserialize(v.into_deserializer()),
             Expression::Object(v) => seed.deserialize(v.into_deserializer()),
-            Expression::Raw(v) => seed.deserialize(v.into_deserializer()),
             Expression::TemplateExpr(v) => seed.deserialize(*v),
             Expression::Variable(v) => seed.deserialize(v.into_deserializer()),
             Expression::Traversal(v) => seed.deserialize(v.into_deserializer()),
@@ -1166,14 +1159,6 @@ impl<'de> de::VariantAccess<'de> for ObjectKey {
     }
 }
 
-impl<'de> IntoDeserializer<'de, Error> for RawExpression {
-    type Deserializer = StringDeserializer<Error>;
-
-    fn into_deserializer(self) -> Self::Deserializer {
-        self.into_inner().into_deserializer()
-    }
-}
-
 impl<'de> IntoDeserializer<'de, Error> for TemplateExpr {
     type Deserializer = Self;
 
@@ -1281,7 +1266,7 @@ impl<'de> IntoDeserializer<'de, Error> for HeredocStripMode {
 
 impl_variant_name! {
     Expression => {
-        Null, Bool, Number, String, Array, Object, Raw, TemplateExpr, Variable,
+        Null, Bool, Number, String, Array, Object, TemplateExpr, Variable,
         Traversal, FuncCall, Parenthesis, Conditional, Operation, ForExpr
     },
     ObjectKey => { Identifier, Expression },

--- a/crates/hcl-rs/src/expr/edit.rs
+++ b/crates/hcl-rs/src/expr/edit.rs
@@ -53,9 +53,6 @@ impl From<Expression> for expr::Expression {
             Expression::Traversal(traversal) => expr::Traversal::from(*traversal).into(),
             Expression::Parenthesis(parens) => expr::Parenthesis::new((*parens).into()).into(),
             Expression::Conditional(cond) => expr::Conditional::from(*cond).into(),
-            Expression::Raw(raw) => {
-                template::StringTemplate::from(template_or_default(raw.as_str())).into()
-            }
         }
     }
 }

--- a/crates/hcl-rs/src/expr/ser/mod.rs
+++ b/crates/hcl-rs/src/expr/ser/mod.rs
@@ -36,7 +36,7 @@ macro_rules! impl_serialize_for_expr {
 
 impl_serialize_for_expr! {
     Conditional ForExpr FuncCall Operation UnaryOp BinaryOp
-    TemplateExpr Heredoc RawExpression Traversal Variable
+    TemplateExpr Heredoc Traversal Variable
 }
 
 impl ser::Serialize for HeredocStripMode {
@@ -72,7 +72,6 @@ impl ser::Serialize for Expression {
             Expression::Conditional(cond) => cond.serialize(serializer),
             Expression::Operation(op) => op.serialize(serializer),
             Expression::ForExpr(expr) => expr.serialize(serializer),
-            Expression::Raw(raw) => raw.serialize(serializer),
         }
     }
 }

--- a/crates/hcl-rs/src/format/impls.rs
+++ b/crates/hcl-rs/src/format/impls.rs
@@ -1,6 +1,4 @@
 use super::{private, Format, Formatter};
-#[allow(deprecated)]
-use crate::expr::RawExpression;
 use crate::expr::{
     BinaryOp, Conditional, Expression, ForExpr, FuncCall, FuncName, Heredoc, HeredocStripMode,
     ObjectKey, Operation, TemplateExpr, Traversal, TraversalOperator, UnaryOp, Variable,
@@ -122,8 +120,6 @@ impl Format for Expression {
             Expression::String(string) => string.format(fmt),
             Expression::Array(array) => format_array(fmt, array.iter()),
             Expression::Object(object) => format_object(fmt, object.iter()),
-            #[allow(deprecated)]
-            Expression::Raw(raw) => raw.format(fmt),
             Expression::TemplateExpr(expr) => expr.format(fmt),
             Expression::Variable(var) => var.format(fmt),
             Expression::Traversal(traversal) => traversal.format(fmt),
@@ -204,19 +200,6 @@ impl<'a> Format for StrKey<'a> {
         } else {
             fmt.write_quoted_string_escaped(self.0)
         }
-    }
-}
-
-#[allow(deprecated)]
-impl private::Sealed for RawExpression {}
-
-#[allow(deprecated)]
-impl Format for RawExpression {
-    fn format<W>(&self, fmt: &mut Formatter<W>) -> Result<()>
-    where
-        W: io::Write,
-    {
-        fmt.write_bytes(self.as_str().as_bytes())
     }
 }
 

--- a/crates/hcl-rs/src/lib.rs
+++ b/crates/hcl-rs/src/lib.rs
@@ -64,10 +64,6 @@ pub use expr::{
     UnaryOperator, Variable,
 };
 
-#[allow(deprecated)]
-#[doc(hidden)]
-pub use expr::RawExpression;
-
 pub use ident::Identifier;
 pub use parser::parse;
 

--- a/crates/hcl-rs/src/macros.rs
+++ b/crates/hcl-rs/src/macros.rs
@@ -361,10 +361,6 @@ macro_rules! object_key {
         $crate::expr::ObjectKey::Identifier($crate::Identifier::unchecked(std::stringify!($ident)))
     };
 
-    (#{$expr:expr}) => {
-        $crate::expr::ObjectKey::Expression($crate::expression!(#{$expr}))
-    };
-
     (($expr:expr)) => {
         $crate::expr::ObjectKey::Expression($crate::expression!($expr))
     };
@@ -586,11 +582,6 @@ macro_rules! expression_internal {
         $crate::expression_internal!(@object $object ($crate::object_key!($key)) ($($rest)*) ($($rest)*));
     };
 
-    // Munch a raw expression key.
-    (@object $object:ident () (#{$key:expr} $($rest:tt)*) $copy:tt) => {
-        $crate::expression_internal!(@object $object ($crate::object_key!(#{$key})) ($($rest)*) ($($rest)*));
-    };
-
     // Munch a parenthesized expression key.
     (@object $object:ident () (($key:expr) $($rest:tt)*) $copy:tt) => {
         $crate::expression_internal!(@object $object ($crate::object_key!(($key))) ($($rest)*) ($($rest)*));
@@ -612,10 +603,6 @@ macro_rules! expression_internal {
 
     (false) => {
         $crate::expr::Expression::Bool(false)
-    };
-
-    (#{$expr:expr}) => {
-        $crate::expr::Expression::Raw(($expr).into())
     };
 
     ([]) => {

--- a/crates/hcl-rs/src/template/mod.rs
+++ b/crates/hcl-rs/src/template/mod.rs
@@ -44,7 +44,7 @@
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //! use hcl::Identifier;
 //! use hcl::expr::Variable;
-//! use hcl::template::{ForDirective, StripMode, Template};
+//! use hcl::template::{ForDirective, Strip, Template};
 //! use std::str::FromStr;
 //!
 //! let raw = r#"
@@ -67,8 +67,8 @@
 //!                 .add_interpolation(Variable::new("item")?)
 //!                 .add_literal("\n")
 //!         )
-//!         .with_for_strip(StripMode::End)
-//!         .with_endfor_strip(StripMode::End)
+//!         .with_for_strip(Strip::End)
+//!         .with_endfor_strip(Strip::End)
 //!     )
 //!     .add_literal("\n");
 //!
@@ -94,10 +94,6 @@ use std::str::FromStr;
 // Re-exported for convenience.
 #[doc(inline)]
 pub use hcl_primitives::template::Strip;
-
-#[doc(hidden)]
-#[deprecated(since = "0.14.0", note = "use `hcl::template::Strip` instead")]
-pub type StripMode = Strip;
 
 /// The main type to represent the HCL template sub-languange.
 ///


### PR DESCRIPTION
BREAKING CHANGE: The deprecated `hcl::expr::RawExpression` type and the `hcl::template::StripMode` alias were removed. Instead of the latter use `hcl::template::Strip` instead. The former has not replacement.