### PR TITLE
fix(parser): allow newlines in function calls and arrays

### DIFF
--- a/crates/hcl-edit/tests/regressions.rs
+++ b/crates/hcl-edit/tests/regressions.rs
@@ -179,3 +179,59 @@ fn issue_350() {
     "#;
     assert!(unicode_input.parse::<Body>().is_ok());
 }
+
+// https://github.com/martinohmann/hcl-rs/issues/367
+#[test]
+fn issue_367() {
+    macro_rules! assert_ok {
+        ($input:expr) => {
+            assert!($input.parse::<Body>().is_ok());
+        };
+    }
+
+    // multiline expressions with function calls
+    assert_ok! {r#"
+        foo = length(
+            true
+            ? "bar"
+            : "baz"
+        )
+    "#};
+    assert_ok! {r#"
+        foo = length(
+            1
+            >
+            2
+        )
+    "#};
+    assert_ok! {r#"
+        foo = length(
+            var
+                .foo
+                [2]
+        )
+    "#};
+
+    // multiline expressions with arrays
+    assert_ok! {r#"
+        foo = [
+            true
+            ? "bar"
+            : "baz"
+        ]
+    "#};
+    assert_ok! {r#"
+        foo = [
+            1
+            >
+            2
+        ]
+    "#};
+    assert_ok! {r#"
+        foo = [
+            var
+                .foo
+                [2]
+        ]
+    "#};
+}

--- a/crates/specsuite/tests/expressions/operators.hcl
+++ b/crates/specsuite/tests/expressions/operators.hcl
@@ -68,7 +68,20 @@ logical_unary "!" {
   f = !false
 }
 
-conditional {
+conditional "regular" {
   t = true ? "a" : "b"
   f = false ? "a" : "b"
+}
+
+conditional "newline" {
+  t = [
+    true
+    ? "a"
+    : "b"
+  ]
+  f = [
+    false
+    ? "a"
+    : "b"
+  ]
 }

--- a/crates/specsuite/tests/expressions/operators.t
+++ b/crates/specsuite/tests/expressions/operators.t
@@ -67,7 +67,13 @@ result = {
     }
   }
   conditional = {
-    t = "a"
-    f = "b"
+    "regular" = {
+      t = "a"
+      f = "b"
+    }
+    "newline" = {
+      t = ["a"]
+      f = ["b"]
+    }
   }
 }


### PR DESCRIPTION
Fixes #367

I don't super understand all the parser stuff here, and I'm not sure how `state` gets reset or inherits or whatever, so I can't tell whether making newlines acceptable with subtly make them acceptable in other, unexpected places, but this seems like it's directionally correct.