### PR TITLE
chore: Fix all warnings

### DIFF
--- a/crates/hcl-edit/examples/interpolation-unwrapping.rs
+++ b/crates/hcl-edit/examples/interpolation-unwrapping.rs
@@ -60,7 +60,7 @@ impl VisitMut for InterpolationUnwrapper {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let Some(filename) = std::env::args().into_iter().skip(1).next() else {
+    let Some(filename) = std::env::args().nth(1) else {
         eprintln!("filename argument required");
         std::process::exit(1);
     };

--- a/crates/hcl-edit/src/parser/expr.rs
+++ b/crates/hcl-edit/src/parser/expr.rs
@@ -168,7 +168,7 @@ fn number<'i, 's>(
     state: &'s RefCell<ExprParseState>,
 ) -> impl Parser<Input<'i>, (), ContextError> + 's {
     move |input: &mut Input<'i>| {
-        num.with_recognized()
+        num.with_taken()
             .map(|(num, repr)| {
                 let mut num = Formatted::new(num);
                 num.set_repr(repr);
@@ -183,7 +183,7 @@ fn neg_number<'i, 's>(
 ) -> impl Parser<Input<'i>, (), ContextError> + 's {
     move |input: &mut Input<'i>| {
         preceded(('-', sp), num)
-            .with_recognized()
+            .with_taken()
             .map(|(num, repr)| {
                 let mut num = Formatted::new(-num);
                 num.set_repr(repr);
@@ -588,9 +588,9 @@ fn for_intro(input: &mut Input) -> PResult<ForIntro> {
     .parse_next(input)
 }
 
-fn for_cond<'i, 's>(
-    state: &'s RefCell<ExprParseState>,
-) -> impl Parser<Input<'i>, ForCond, ContextError> + 's {
+fn for_cond<'i>(
+    state: &RefCell<ExprParseState>,
+) -> impl Parser<Input<'i>, ForCond, ContextError> + '_ {
     move |input: &mut Input| {
         prefix_decorated(
             ws,
@@ -737,9 +737,9 @@ fn func_namespace_components<'i, 's>(
     }
 }
 
-fn func_args<'i, 's>(
-    state: &'s RefCell<ExprParseState>,
-) -> impl Parser<Input<'i>, FuncArgs, ContextError> + 's {
+fn func_args<'i>(
+    state: &RefCell<ExprParseState>,
+) -> impl Parser<Input<'i>, FuncArgs, ContextError> + '_ {
     move |input: &mut Input| {
         #[derive(Copy, Clone)]
         enum Trailer {

--- a/crates/hcl-edit/src/parser/number.rs
+++ b/crates/hcl-edit/src/parser/number.rs
@@ -23,7 +23,7 @@ fn float(input: &mut Input) -> PResult<f64> {
     let fraction = preceded('.', digit1);
 
     terminated(digit1, alt((terminated(fraction, opt(exponent)), exponent)))
-        .recognize()
+        .take()
         .try_map(|s: &str| f64::from_str(s))
         .parse_next(input)
 }
@@ -34,7 +34,7 @@ fn exponent<'a>(input: &mut Input<'a>) -> PResult<&'a str> {
         opt(one_of(b"+-")),
         cut_err(digit1).context(StrContext::Expected(StrContextValue::Description("digit"))),
     )
-        .recognize()
+        .take()
         .parse_next(input)
 }
 
@@ -60,10 +60,12 @@ mod tests {
     }
 
     #[test]
+    // Strict comparison is safe because we don't do any math with these floats
+    #[allow(clippy::float_cmp)]
     fn parse_float() {
         let tests: &[(&str, f64)] = &[
             ("1.0", 1.0),
-            ("1e10", 10000000000.0),
+            ("1e10", 10_000_000_000.0),
             ("2.5E3", 2500.0),
             ("42e-3", 0.042),
             ("0.1E-4", 0.00001),

--- a/crates/hcl-edit/src/parser/string.rs
+++ b/crates/hcl-edit/src/parser/string.rs
@@ -117,7 +117,7 @@ where
         1..,
         preceded(not(alt((escaped_marker.void(), literal_end.void()))), any),
     ))
-    .recognize()
+    .take()
 }
 
 /// Parse an escaped start marker for a template interpolation or directive.
@@ -186,7 +186,7 @@ pub(super) fn ident(input: &mut Input) -> PResult<Decorated<Ident>> {
 
 pub(super) fn str_ident<'a>(input: &mut Input<'a>) -> PResult<&'a str> {
     (one_of(is_id_start), take_while(0.., is_id_continue))
-        .recognize()
+        .take()
         .parse_next(input)
 }
 

--- a/crates/hcl-edit/src/parser/template.rs
+++ b/crates/hcl-edit/src/parser/template.rs
@@ -44,7 +44,7 @@ pub(super) fn heredoc_template<'a>(
         //
         // Handling this case via parser combinators is quite tricky and thus we'll manually add
         // the line ending to the last template element below.
-        let heredoc_end = (line_ending, space0, delim).recognize();
+        let heredoc_end = (line_ending, space0, delim).take();
         let literal_end = alt(("${", "%{", heredoc_end));
         let literal = template_literal(literal_end);
 

--- a/crates/hcl-edit/src/parser/tests.rs
+++ b/crates/hcl-edit/src/parser/tests.rs
@@ -48,12 +48,12 @@ fn roundtrip_expr() {
         "{ foo = 1 #comment\n }",
         "{ foo = 1, #comment\n bar = 1 }",
         "<<HEREDOC\nHEREDOC",
-        indoc! {r#"
+        indoc! {r"
             <<HEREDOC
             ${foo}
             %{if asdf}qux%{endif}
             heredoc
-            HEREDOC"#},
+            HEREDOC"},
         r#""foo ${bar} $${baz}, %{if cond ~} qux %{~ endif}""#,
         r#""${var.l ? "us-east-1." : ""}""#,
         "element(concat(aws_kms_key.key-one.*.arn, aws_kms_key.key-two.*.arn), 0)",
@@ -88,13 +88,13 @@ fn roundtrip_body() {
         "block { attr = 1 }\n",
         "foo = \"bar\"\nbar = 2\n",
         "foo = \"bar\"\nbar = 3",
-        indoc! {r#"
+        indoc! {r"
             indented_heredoc = <<-EOT
                 ${foo}
               %{if asdf}qux%{endif}bar
                   heredoc
                 EOT
-        "#},
+        "},
         "ami = \"ami-5f6495430e7781fe5\" // Ubuntu 20.04 LTS\n",
         "ami = \"ami-5f6495430e7781fe5\" /* Ubuntu 20.04 LTS */\n",
         "array =   [1, 2, 3]\n",
@@ -102,7 +102,7 @@ fn roundtrip_body() {
     ];
 
     let tests = testdata::load().unwrap();
-    assert!(tests.len() > 0);
+    assert!(!tests.is_empty());
 
     for test in &tests {
         inputs.push(&test.input);
@@ -117,12 +117,12 @@ fn roundtrip_body() {
 fn roundtrip_template() {
     let inputs = [
         "foo $${baz} ${bar}, %{if cond ~} qux %{~ endif}",
-        indoc! {r#"
+        indoc! {r"
             Bill of materials:
             %{ for item in items ~}
             - ${item}
             %{ endfor ~}
-        "#},
+        "},
         "literal $${escaped} ${value}",
     ];
 

--- a/crates/hcl-primitives/src/number.rs
+++ b/crates/hcl-primitives/src/number.rs
@@ -538,7 +538,7 @@ mod tests {
         assert_op!(int!(3u64) % int!(2u64), int!(1u64), is_u64);
         assert_op!(
             float!(4.1) % float!(2.0),
-            float!(0.09999999999999964),
+            float!(0.099_999_999_999_999_64),
             is_f64
         );
         assert_op!(int!(4u64) % int!(2u64), int!(0u64), is_u64);

--- a/crates/hcl-rs/examples/in-place-expr-evaluation.rs
+++ b/crates/hcl-rs/examples/in-place-expr-evaluation.rs
@@ -1,7 +1,7 @@
 use hcl::eval::{Context, Evaluate};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let Some(filename) = std::env::args().into_iter().skip(1).next() else {
+    let Some(filename) = std::env::args().nth(1) else {
         eprintln!("filename argument required");
         std::process::exit(1);
     };
@@ -54,7 +54,7 @@ mod test {
             }
         "#};
 
-        let mut body = hcl::parse(&input).unwrap();
+        let mut body = hcl::parse(input).unwrap();
         let mut ctx = Context::new();
         ctx.declare_var(
             "var",

--- a/crates/hcl-rs/src/expr/ser/tests.rs
+++ b/crates/hcl-rs/src/expr/ser/tests.rs
@@ -25,7 +25,7 @@ fn roundtrip() {
     assert_expr(
         Expression::from(Variable::unchecked("var")),
         Expression::from(Variable::unchecked("var")),
-    )
+    );
 }
 
 #[test]

--- a/crates/hcl-rs/tests/common/mod.rs
+++ b/crates/hcl-rs/tests/common/mod.rs
@@ -31,7 +31,7 @@ where
 }
 
 #[track_caller]
-pub fn assert_format_builder<'a, T>(builder: FormatterBuilder<'a>, value: T, expected: &str)
+pub fn assert_format_builder<T>(builder: FormatterBuilder<'_>, value: T, expected: &str)
 where
     T: Format,
 {


### PR DESCRIPTION
- Auto-fix clippy warnings
- Allow strict float comparison in one spot
- Fix winnow deprecation warnings (replace recognize() with take())