### PR TITLE
feat: Add from_body to Deserializer

### DIFF
--- a/crates/hcl-rs/src/de/mod.rs
+++ b/crates/hcl-rs/src/de/mod.rs
@@ -30,6 +30,11 @@ impl Deserializer {
         let body = parser::parse(input)?;
         Ok(Deserializer { body })
     }
+
+    /// Creates a HCL deserializer from a HCL body
+    pub fn from_body(body: Body) -> Self {
+        Self { body }
+    }
 }
 
 /// Deserialize an instance of type `T` from a string of HCL text.


### PR DESCRIPTION
This exposes a method to create an HCL `Deserializer` directly from a `Body`. I know the [from_body global fn](https://docs.rs/hcl-rs/latest/hcl/fn.from_body.html) already exists, but I specifically need a `Deserializer` so I can pass it to [serde_path_to_error::deserialize](https://docs.rs/serde_path_to_error/latest/serde_path_to_error/fn.deserialize.html).

I know `Body` already implements `IntoDeserializer`, but that creates a `NewtypeStructDeserializer<Vec<Structure>>` which doesn't seem to work for deserializing to arbitrary `Deserialize` types.

I didn't add any tests to this because it's so trivial. Happy to write one though if you'd prefer to have it.