### PR TITLE
fix(parser): allow multiline expressions in more places

### DIFF
--- a/crates/hcl-edit/src/parser/string.rs
+++ b/crates/hcl-edit/src/parser/string.rs
@@ -34,13 +34,11 @@ where
 
         loop {
             match fragment_parser.parse_next(input) {
-                Ok(fragment) => {
-                    match fragment {
-                        StringFragment::Literal(s) => string.to_mut().push_str(s),
-                        StringFragment::EscapedChar(c) => string.to_mut().push(c),
-                        StringFragment::EscapedMarker(m) => string.to_mut().push_str(m.unescape()),
-                    }
-                }
+                Ok(fragment) => match fragment {
+                    StringFragment::Literal(s) => string.to_mut().push_str(s),
+                    StringFragment::EscapedChar(c) => string.to_mut().push(c),
+                    StringFragment::EscapedMarker(m) => string.to_mut().push_str(m.unescape()),
+                },
                 Err(_) => return Ok(string),
             }
         }

--- a/crates/hcl-edit/src/parser/template.rs
+++ b/crates/hcl-edit/src/parser/template.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-use super::expr::expr;
+use super::expr::{expr, multiline_expr};
 use super::repr::{decorated, spanned};
 use super::string::{
     build_string, cut_char, cut_ident, cut_tag, quoted_string_fragment, raw_string,
@@ -96,7 +96,7 @@ where
 }
 
 fn interpolation(input: &mut Input) -> ModalResult<Interpolation> {
-    control("${", decorated(ws, expr, ws))
+    control("${", decorated(ws, multiline_expr, ws))
         .map(|(expr, strip)| {
             let mut interp = Interpolation::new(expr);
             interp.strip = strip;

--- a/crates/hcl-edit/tests/regressions.rs
+++ b/crates/hcl-edit/tests/regressions.rs
@@ -4,6 +4,18 @@ use hcl_edit::template::{Element, Interpolation, Template};
 use hcl_edit::{Ident, Span};
 use pretty_assertions::assert_eq;
 
+macro_rules! assert_ok {
+    ($input:expr) => {
+        assert!($input.parse::<Body>().is_ok());
+    };
+}
+
+macro_rules! assert_err {
+    ($input:expr) => {
+        assert!($input.parse::<Body>().is_err());
+    };
+}
+
 // https://github.com/martinohmann/hcl-rs/issues/248
 #[test]
 fn issue_248() {
@@ -101,20 +113,9 @@ fn issue_294() {
 }
 
 // https://github.com/martinohmann/hcl-rs/issues/319
+// https://github.com/martinohmann/hcl-rs/issues/426
 #[test]
-fn issue_319() {
-    macro_rules! assert_ok {
-        ($input:expr) => {
-            assert!($input.parse::<Body>().is_ok());
-        };
-    }
-
-    macro_rules! assert_err {
-        ($input:expr) => {
-            assert!($input.parse::<Body>().is_err());
-        };
-    }
-
+fn issues_319_426() {
     // single line expressions with parenthesis
     assert_ok! {r#"
         foo = (true ? "bar" : "baz")
@@ -164,6 +165,24 @@ fn issue_319() {
             .foo
             [2]
     "#};
+
+    // multiline expressions in traversal index operator
+    assert_ok! {r#"
+        foo = var.foo[
+            bar &&
+            baz ? 0 :
+            1
+        ]
+    "#};
+
+    // multiline expressions in template string interpolation
+    assert_ok! {r#"
+        foo = "template-string-${
+            bar &&
+            baz ? "qux" :
+            ""
+        }"
+    "#};
 }
 
 // https://github.com/martinohmann/hcl-rs/issues/350
@@ -183,18 +202,6 @@ fn issue_350() {
 // https://github.com/martinohmann/hcl-rs/issues/367
 #[test]
 fn issue_367() {
-    macro_rules! assert_ok {
-        ($input:expr) => {
-            assert!($input.parse::<Body>().is_ok());
-        };
-    }
-
-    macro_rules! assert_err {
-        ($input:expr) => {
-            assert!($input.parse::<Body>().is_err());
-        };
-    }
-
     // multiline expressions with function calls
     assert_ok! {r#"
         foo = length(


### PR DESCRIPTION
Fixes #426.

I also found another case where multiline expressions are valid but the parser didn't handle so far and fixed that along the way.

Also contains some `rustfmt` changes.