### PR TITLE
feat: add simple `hcl2json` CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "assert-json-diff"
@@ -87,21 +137,36 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.92",
 ]
 
 [[package]]
@@ -109,6 +174,12 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "criterion"
@@ -141,16 +212,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -211,6 +272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,13 +329,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+name = "hcl2json"
+version = "0.1.0"
 dependencies = [
- "libc",
+ "anyhow",
+ "clap",
+ "glob",
+ "hcl-rs",
+ "rayon",
+ "serde_json",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
@@ -286,6 +362,12 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -331,12 +413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.144"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,20 +446,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -449,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -459,14 +531,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -561,6 +631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vecmap-rs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,12 +718,11 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -739,6 +820,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,13 @@ members = [
     "crates/hcl-edit",
     "crates/hcl-primitives",
     "crates/hcl-rs",
+    "crates/hcl2json",
     "crates/specsuite",
     "crates/testdata"
 ]
 resolver = "2"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Configuration Language (HCL):
   Parse and modify HCL documents while preserving whitespace and comments.
 - [`hcl-primitives`](https://github.com/martinohmann/hcl-rs/blob/main/crates/hcl-primitives):
   Primitives used by the HCL sub-languages.
+- [`hcl2json`](https://github.com/martinohmann/hcl-rs/blob/main/crates/hcl2json):
+  CLI program for converting HCL to JSON.
 
 ## Feature parity with the go-hcl implementation
 

--- a/crates/hcl2json/Cargo.toml
+++ b/crates/hcl2json/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "hcl2json"
+version = "0.1.0"
+authors = ["Martin Ohmann <martinohmann@gmail.com>"]
+license = "MIT OR Apache-2.0"
+description = "CLI program for converting HCL to JSON"
+repository = "https://github.com/martinohmann/hcl-rs"
+documentation = "https://docs.rs/hcl2json/"
+keywords = ["hcl", "json", "serialization"]
+categories = ["encoding"]
+readme = "README.md"
+edition = "2024"
+include = [
+  "CHANGELOG.md",
+  "Cargo.toml",
+  "LICENSE*",
+  "README.md",
+  "benches/**/*",
+  "examples/**/*",
+  "src/**/*",
+  "tests/**/*"
+]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
+
+[dependencies]
+anyhow = "1.0.98"
+clap = { version = "4.5.40", features = ["derive"] }
+glob = "0.3.2"
+hcl-rs = { version = "0.18.5", path = "../hcl-rs", features = ["perf"] }
+rayon = "1.10.0"
+serde_json = "1.0.140"

--- a/crates/hcl2json/LICENSE-APACHE
+++ b/crates/hcl2json/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/hcl2json/LICENSE-MIT
+++ b/crates/hcl2json/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/hcl2json/README.md
+++ b/crates/hcl2json/README.md
@@ -1,0 +1,69 @@
+# hcl2json
+
+[![Build Status](https://github.com/martinohmann/hcl-rs/workflows/ci/badge.svg)](https://github.com/martinohmann/hcl-rs/actions?query=workflow%3Aci)
+[![crates.io](https://img.shields.io/crates/v/hcl2json)](https://crates.io/crates/hcl2json)
+[![docs.rs](https://img.shields.io/docsrs/hcl2json)](https://docs.rs/hcl2json)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+CLI program for converting HCL to JSON.
+
+## Installation
+
+```sh
+cargo install hcl2json
+```
+
+## Usage
+
+### Convert a file from `stdin`
+
+```sh
+cat file.hcl | hcl2json
+```
+
+### Convert multiple files to JSON
+
+```sh
+hcl2json file.hcl other-file.tf
+```
+
+**Note**: When converting multiple files or directories the resulting JSON is a
+map keyed by input file path.
+
+### Recursively convert files from a directory
+
+```sh
+hcl2json --glob '**/*.tf' dir/
+```
+
+**Note**: The command above is equivalent to `hcl2json dir/**/*.tf` but may
+have better performance in scripts when there are hundreds of matching files.
+
+### Simplify and pretty-print
+
+Simplify HCL expressions where possible and emit pretty-printed JSON:
+
+```sh
+hcl2json --simplify --pretty file.hcl
+```
+
+## Similar tools
+
+- [tmccombs/hcl2json](https://github.com/tmccombs/hcl2json): Converts single
+  HCL files. Sweet and simple.
+- [Bonial-International-GmbH/hcl2json](https://github.com/Bonial-International-GmbH/hcl2json):
+  Supports bulk conversion but is generally slower than this implementation.
+
+## Contributing
+
+Contributions are welcome! Please read
+[`CONTRIBUTING.md`](https://github.com/martinohmann/hcl-rs/blob/main/CONTRIBUTING.md)
+before creating a PR.
+
+## License
+
+The source code of hcl2json is licensed under either of [Apache License, Version
+2.0](https://github.com/martinohmann/hcl-rs/blob/main/LICENSE-APACHE) or [MIT
+license](https://github.com/martinohmann/hcl-rs/blob/main/LICENSE-MIT) at your
+option.

--- a/crates/hcl2json/src/main.rs
+++ b/crates/hcl2json/src/main.rs
@@ -1,0 +1,129 @@
+use anyhow::{Result, bail};
+use clap::Parser;
+use hcl::eval::{Context, Evaluate};
+use hcl::structure::Body;
+use rayon::prelude::*;
+use serde_json::Value;
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+/// Converts HCL to JSON.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// A glob pattern to match files when recursively scanning directories.
+    #[arg(short, long)]
+    glob: Option<String>,
+    /// Pretty-print the resulting JSON.
+    #[arg(short, long)]
+    pretty: bool,
+    /// Attempt to simply expressions which don't contain any variables or unknown functions.
+    #[arg(short, long)]
+    simplify: bool,
+    /// Paths to read HCL files from.
+    ///
+    /// This can be files or directories. Directories require passing a glob pattern via --glob.
+    paths: Vec<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let writer = BufWriter::new(io::stdout());
+
+    if args.paths.is_empty() {
+        convert(io::stdin(), writer, &args)
+    } else {
+        if args.paths.len() == 1 {
+            let path = &args.paths[0];
+
+            if path == &PathBuf::from("-") {
+                return convert(io::stdin(), writer, &args);
+            }
+
+            if !path.is_dir() {
+                return convert(File::open(path)?, writer, &args);
+            }
+        }
+
+        let mut paths = Vec::with_capacity(args.paths.len());
+
+        for path in &args.paths {
+            if path.is_dir() {
+                let Some(pattern) = &args.glob else {
+                    bail!("--glob is required if directory arguments are specified")
+                };
+                paths.extend(glob_files(path, pattern)?);
+            } else {
+                paths.push(path.clone());
+            }
+        }
+
+        bulk_convert(&paths, writer, &args)
+    }
+}
+
+#[inline]
+fn convert<R: Read, W: Write>(reader: R, writer: W, args: &Args) -> Result<()> {
+    let value = read_hcl(reader, args)?;
+    write_json(writer, &value, args)
+}
+
+fn bulk_convert<W: Write>(paths: &[PathBuf], mut writer: W, args: &Args) -> Result<()> {
+    if paths.is_empty() {
+        writer.write_all(b"{}")?;
+        return Ok(());
+    }
+
+    let results = paths
+        .into_par_iter()
+        .map(|path| {
+            let value = read_hcl(File::open(path)?, args)?;
+            let path = path.display().to_string();
+            Ok((path, value))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let value = Value::from_iter(results);
+    write_json(writer, &value, args)
+}
+
+#[inline]
+fn read_hcl<R: Read>(reader: R, args: &Args) -> Result<Value> {
+    let reader = BufReader::new(reader);
+
+    let value = if args.simplify {
+        let mut body: Body = hcl::from_reader(reader)?;
+        let ctx = Context::default();
+        // Evaluate as much as possible and ignore errors.
+        _ = body.evaluate_in_place(&ctx);
+        hcl::from_body(body)?
+    } else {
+        hcl::from_reader(reader)?
+    };
+
+    Ok(value)
+}
+
+#[inline]
+fn write_json<W: Write>(writer: W, value: &Value, args: &Args) -> Result<()> {
+    if args.pretty {
+        serde_json::to_writer_pretty(writer, value)?;
+    } else {
+        serde_json::to_writer(writer, value)?;
+    }
+
+    Ok(())
+}
+
+fn glob_files(path: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
+    let path_pattern = path.join(pattern);
+
+    glob::glob(&path_pattern.to_string_lossy())?
+        .filter_map(|result| match result {
+            Ok(path) => path.is_file().then_some(Ok(path)),
+            Err(err) => Some(Err(err.into())),
+        })
+        .collect()
+}


### PR DESCRIPTION
This both acts as demo and is acutally useful. Pretty basic still, but much faster than https://github.com/Bonial-International-GmbH/hcl2json which I wrote for work some years back for parsing thousands of `*.tf` files.

I had this one laying around for far too long now and need to get it out.