### PR TITLE
fix: emit correct empty collection if paths are empty

### DIFF
--- a/crates/hcl2json/src/main.rs
+++ b/crates/hcl2json/src/main.rs
@@ -111,12 +111,7 @@ fn convert<R: Read, W: Write>(reader: R, writer: W, args: &Args) -> Result<()> {
     write_json(writer, &value, args)
 }
 
-fn bulk_convert<W: Write>(paths: &[PathBuf], mut writer: W, args: &Args) -> Result<()> {
-    if paths.is_empty() {
-        writer.write_all(b"{}")?;
-        return Ok(());
-    }
-
+fn bulk_convert<W: Write>(paths: &[PathBuf], writer: W, args: &Args) -> Result<()> {
     let iter = paths.into_par_iter();
 
     let results = if args.continue_on_error {


### PR DESCRIPTION
There are two kinds of empty collections to emit when paths are empty:

- `[]` if `--file-paths/-P` **is not**  provided
- `{}` if `--file-paths/-P` **is** provided

The current logic didn't account for that and even got it wrong for the default case, which should emit `[]`.

We'll just remove this fast path since it does not bring any performance benefit (`bulk_convert` is only called exactly once) but needs to be kept in sync with the rest of the logic.