### PR TITLE
fix: panic when parsing empty expression

### DIFF
--- a/crates/hcl-edit/src/parser/error.rs
+++ b/crates/hcl-edit/src/parser/error.rs
@@ -117,6 +117,16 @@ impl Location {
 
 fn locate_error<'a>(err: &'a ParseError<Input<'a>, ContextError>) -> (&'a [u8], Location) {
     let input = err.input().as_bytes();
+    if input.is_empty() {
+        return (
+            input,
+            Location {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+        );
+    }
     let offset = err.offset().min(input.len() - 1);
     let column_offset = err.offset() - offset;
 

--- a/crates/hcl-edit/tests/regressions.rs
+++ b/crates/hcl-edit/tests/regressions.rs
@@ -334,3 +334,9 @@ fn issue_452() {
     ));
     assert_eq!(expected, parsed);
 }
+
+// https://github.com/martinohmann/hcl-rs/pull/457
+#[test]
+fn issue_457() {
+    assert!(hcl_edit::parser::parse_expr("").is_err());
+}


### PR DESCRIPTION
`hcl_edit::parser::parse_expr("")` panics when finding the span (subtracts from 0usize). I have tried to do a saturating_sub, but then it still fails later at `a..=b`, where b=0 and I didn't want to get into changing the semantics of b to change it to `a..b`.