### PR TITLE
fix: prevent heredoc delimiter prefix matching against longer identifier

### DIFF
--- a/crates/hcl-edit/src/parser/expr.rs
+++ b/crates/hcl-edit/src/parser/expr.rs
@@ -15,7 +15,7 @@ use crate::expr::{
 use crate::template::HeredocTemplate;
 use crate::{Decorate, Decorated, Formatted, Ident, RawString, SetSpan, Spanned};
 
-use hcl_primitives::ident::is_id_start;
+use hcl_primitives::ident::{is_id_continue, is_id_start};
 use std::cell::RefCell;
 use winnow::ascii::{crlf, dec_uint, line_ending, newline, space0};
 use winnow::combinator::{
@@ -679,9 +679,9 @@ fn heredoc<'i>(
             spanned(heredoc_template(delim)),
             terminated(
                 raw_string(space0),
-                cut_err(delim).context(StrContext::Expected(StrContextValue::Description(
-                    "heredoc end delimiter",
-                ))),
+                cut_err(terminated(delim, not(one_of(is_id_continue)))).context(
+                    StrContext::Expected(StrContextValue::Description("heredoc end delimiter")),
+                ),
             ),
         )
             .parse_next(input)?;

--- a/crates/hcl-edit/src/parser/template.rs
+++ b/crates/hcl-edit/src/parser/template.rs
@@ -16,7 +16,10 @@ use crate::{SetSpan, Span, Spanned};
 
 use std::borrow::Cow;
 use winnow::ascii::{line_ending, space0};
-use winnow::combinator::{alt, delimited, opt, preceded, repeat, separated_pair, terminated};
+use winnow::combinator::{alt, delimited, not, opt, preceded, repeat, separated_pair, terminated};
+use winnow::token::one_of;
+
+use hcl_primitives::ident::is_id_continue;
 
 pub(super) fn string_template(input: &mut Input) -> ModalResult<StringTemplate> {
     delimited('"', elements(build_string(quoted_string_fragment)), '"')
@@ -44,7 +47,7 @@ pub(super) fn heredoc_template<'a>(
         //
         // Handling this case via parser combinators is quite tricky and thus we'll manually add
         // the line ending to the last template element below.
-        let heredoc_end = (line_ending, space0, delim).take();
+        let heredoc_end = (line_ending, space0, delim, not(one_of(is_id_continue))).take();
         let literal_end = alt(("${", "%{", heredoc_end));
         let literal = template_literal(literal_end);
 

--- a/crates/hcl-edit/src/parser/tests.rs
+++ b/crates/hcl-edit/src/parser/tests.rs
@@ -174,6 +174,32 @@ fn roundtrip_template() {
 }
 
 #[test]
+fn heredoc_prefix_delimiter() {
+    // Empty heredoc (non-indented) followed by heredoc with prefix-sharing delimiter.
+    let input = "a = <<EOF\nEOF\nb = <<EOFTF\ncontent\nEOFTF\n";
+    assert_roundtrip!(input, body);
+
+    // Non-empty indented heredoc followed by heredoc with prefix-sharing delimiter.
+    let input = indoc! {r#"
+        a = <<-EOF
+          hello
+          EOF
+        b = <<-EOFTF
+          world
+          EOFTF
+    "#};
+    assert_roundtrip!(input, body);
+
+    // Non-empty non-indented heredoc followed by heredoc with prefix-sharing delimiter.
+    let input = "a = <<EOF\nhello\nEOF\nb = <<EOFTF\nworld\nEOFTF\n";
+    assert_roundtrip!(input, body);
+
+    // Empty indented heredoc followed by prefix-sharing delimiter parses successfully.
+    let input = "a = <<-EOF\nEOF\nb = <<-EOFTF\ncontent\nEOFTF\n";
+    parse_complete(input, body).expect("should parse empty <<-EOF followed by <<-EOFTF");
+}
+
+#[test]
 fn invalid_exprs() {
     let inputs = [
         "{ , }",


### PR DESCRIPTION
An empty heredoc (e.g. `<<EOF` with `EOF` on the next line) followed by a heredoc whose marker starts with the same prefix (e.g. `EOFTF`) caused a parse error. The delimiter was matched as a string prefix rather than a whole word, so `EOF` would incorrectly match the start of `EOFTF`.

This PR addresses the bug by adding `not(one_of(is_id_continue))` after the delimiter match in both `heredoc_end` (template.rs) and the closing delimiter check (expr.rs) to ensure the delimiter is not a prefix of a longer identifier.