### PR TITLE
fix: avoid panic when parsing i64's min value literal

### DIFF
--- a/crates/hcl-edit/tests/regressions.rs
+++ b/crates/hcl-edit/tests/regressions.rs
@@ -340,3 +340,17 @@ fn issue_452() {
 fn issue_457() {
     assert!(hcl_edit::parser::parse_expr("").is_err());
 }
+
+// The string literal "-9223372036854775808" (i64's minimum value) is parsed
+// into an intermediate value that caused a panic before it could be converted
+// into its valid final value (i64::MIN).
+// That intermediate value (i.e., 9,223,372,036,854,775,808) is one larger than
+// the biggest positive i64 (i.e., 9,223,372,036,854,775,807).
+#[test]
+fn parse_i64_min_literal() {
+    let input = "-9223372036854775808";
+
+    let parsed: Expression = input.parse().unwrap();
+    let expected = Expression::from(i64::MIN);
+    assert_eq!(expected, parsed);
+}

--- a/crates/hcl-primitives/src/number.rs
+++ b/crates/hcl-primitives/src/number.rs
@@ -166,6 +166,7 @@ impl Neg for N {
 
     fn neg(self) -> Self::Output {
         match self {
+            N::PosInt(value) if value == i64::MIN.unsigned_abs() => N::NegInt(i64::MIN),
             #[allow(clippy::cast_possible_wrap)]
             N::PosInt(value) => N::NegInt(-(value as i64)),
             N::NegInt(value) => N::from(-value),
@@ -497,6 +498,7 @@ mod tests {
         assert_op!(-int!(1u64), int!(-1i64), is_i64);
         assert_op!(-float!(1.5), float!(-1.5), is_f64);
         assert_op!(-float!(1.0), int!(-1i64), is_i64);
+        assert_op!(-int!(9_223_372_036_854_775_808u64), int!(i64::MIN), is_i64);
     }
 
     #[test]


### PR DESCRIPTION
The string literal "-9223372036854775808" (i64's minimum value) is parsed into an intermediate value that caused a panic before it could be converted into its valid final value (i64::MIN). That intermediate value (i.e., `9,223,372,036,854,775,808`) is one larger than the biggest possible positive i64 (i.e., `9,223,372,036,854,775,807`). 

This PR adds a special case in the `Neg` trait implementation for the `N` enum to avoid the panic, along with a couple tests.