### PR TITLE
fix: reject invalid string escapes instead of silently dropping them

### DIFF
--- a/crates/hcl-edit/src/parser/string.rs
+++ b/crates/hcl-edit/src/parser/string.rs
@@ -7,6 +7,7 @@ use crate::{Decorated, Ident, RawString};
 use hcl_primitives::ident::{is_id_continue, is_id_start};
 use std::borrow::Cow;
 use winnow::combinator::{alt, cut_err, delimited, empty, fail, not, opt, preceded, repeat};
+use winnow::error::ErrMode;
 use winnow::token::{any, one_of, take, take_while};
 
 pub(super) fn string(input: &mut Input) -> ModalResult<String> {
@@ -39,7 +40,10 @@ where
                     StringFragment::EscapedChar(c) => string.to_mut().push(c),
                     StringFragment::EscapedMarker(m) => string.to_mut().push_str(m.unescape()),
                 },
-                Err(_) => return Ok(string),
+                // A backtrack marks the end of the string; a cut (e.g. an invalid escape
+                // sequence) must surface instead of being silently dropped.
+                Err(ErrMode::Backtrack(_)) => return Ok(string),
+                Err(err) => return Err(err),
             }
         }
     }

--- a/crates/hcl-edit/src/parser/tests.rs
+++ b/crates/hcl-edit/src/parser/tests.rs
@@ -216,3 +216,45 @@ fn invalid_exprs() {
         );
     }
 }
+
+#[test]
+fn valid_escape_sequences() {
+    let tests = [
+        (r#""a\nb""#, "a\nb"),
+        (r#""a\rb""#, "a\rb"),
+        (r#""a\tb""#, "a\tb"),
+        (r#""a\\b""#, "a\\b"),
+        (r#""a\"b""#, "a\"b"),
+        (r#""a\u2665b""#, "a\u{2665}b"),
+        (r#""a\U0001f600b""#, "a\u{1f600}b"),
+    ];
+
+    for (input, expected) in tests {
+        let parsed = parse_complete(input, expr).unwrap();
+        assert_eq!(parsed.as_str(), Some(expected), "input: `{input}`");
+    }
+}
+
+#[test]
+fn invalid_escape_sequences() {
+    // An invalid escape selector must raise a parse error rather than silently
+    // dropping the escaped character. The leading-literal cases regress the
+    // variant where the invalid escape reaches the string-building loop.
+    let inputs = [
+        r#""\q""#,
+        r#""pre\qpost""#,
+        r#""z\ay""#,
+        r#""\x41""#,
+        r#""\0""#,
+        r#""\v""#,
+        r#""\'""#,
+        r#""\e""#,
+    ];
+
+    for input in inputs {
+        assert!(
+            parse_complete(input, expr).is_err(),
+            "expected invalid escape sequence to be rejected: `{input}`",
+        );
+    }
+}


### PR DESCRIPTION
Fixes the parser-bug half of #548. `build_string`'s loop treated any parser
error as end-of-string, so a cut error from `escaped_char` on an unknown
escape selector (e.g. `\q`) was swallowed and the invalid escape silently
dropped instead of raising: `"pre\qpost"` parsed to `prepost`.

Now only a backtrack ends the string; a cut propagates as the real error.

Added `valid_escape_sequences` / `invalid_escape_sequences` tests in
`crates/hcl-edit/src/parser/tests.rs`. Left the `\b \f \/` question (the
spec-implementation half you mentioned) for a separate PR once you've decided
how you want that one framed.
